### PR TITLE
Add stress test for 3d and combine in one function

### DIFF
--- a/tests/src/resultcollection.hh
+++ b/tests/src/resultcollection.hh
@@ -11,20 +11,20 @@ auto getVertexPositions(FiniteElement& fe) {
   constexpr int dim            = FiniteElement::Traits::mydim;
   const auto& element          = fe.gridElement();
   const auto& referenceElement = Dune::referenceElement<double, dim>(element.type());
-  const int nodes              = referenceElement.size(dim);
+  const int numberOfVertices   = referenceElement.size(dim);
 
   std::vector<typename FiniteElement::GridElementEntityType::Geometry::LocalCoordinate> positions;
-  for (auto i : std::views::iota(0, nodes))
+  for (auto i : std::views::iota(0, numberOfVertices))
     positions.push_back(referenceElement.position(i, dim));
 
   return positions;
 }
 
 inline auto linearStressResultsOfSquare = [](auto& nonLinearOperator, auto& fe) {
-  constexpr int nodes      = 4;
+  constexpr int vertices   = 4;
   constexpr int quantities = 3;
 
-  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  Eigen::Matrix<double, vertices, quantities> expectedStress;
   if constexpr (requires { fe.setEASType(4); }) {
     fe.setEASType(4);
     expectedStress << 1214.28571429, 1214.28571429, 384.61538462, 1214.28571429, 214.28571429, 384.61538462,
@@ -46,10 +46,10 @@ inline auto linearStressResultsOfSquare = [](auto& nonLinearOperator, auto& fe) 
 };
 
 inline auto linearStressResultsOfCube = [](auto& nonLinearOperator, auto& fe) {
-  constexpr int nodes      = 8;
+  constexpr int vertices   = 8;
   constexpr int quantities = 6;
 
-  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  Eigen::Matrix<double, vertices, quantities> expectedStress;
   expectedStress << 576.92307692, 1346.15384615, 576.92307692, 384.61538462, 0, 384.61538462, 0, 0, 0, 0, 0, 0,
       -1346.15384615, 192.30769231, -1346.15384615, 0, -769.23076923, 0, -1346.15384615, -576.92307692, -576.92307692,
       0, -384.61538462, -384.61538462, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -576.92307692, -576.92307692, -1346.15384615,
@@ -67,10 +67,10 @@ inline auto linearStressResultsOfCube = [](auto& nonLinearOperator, auto& fe) {
 };
 
 inline auto linearStressResultsOfTriangle = [](auto& nonLinearOperator, auto& fe) {
-  constexpr int nodes      = 3;
+  constexpr int vertices   = 3;
   constexpr int quantities = 3;
 
-  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  Eigen::Matrix<double, vertices, quantities> expectedStress;
   expectedStress.rowwise() = Eigen::Matrix<double, 1, quantities>{2197.80219780, 659.34065934, 384.61538462};
 
   auto& displacement = nonLinearOperator.firstParameter();
@@ -85,10 +85,10 @@ inline auto linearStressResultsOfTriangle = [](auto& nonLinearOperator, auto& fe
 };
 
 inline auto linearStressResultsOfTetrahedron = [](auto& nonLinearOperator, auto& fe) {
-  constexpr int nodes      = 4;
+  constexpr int vertices   = 4;
   constexpr int quantities = 6;
 
-  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  Eigen::Matrix<double, vertices, quantities> expectedStress;
   expectedStress.rowwise()
       = Eigen::Matrix<double, 1, quantities>{576.92307692, 1346.15384615, 576.92307692, 0, 384.61538462, 769.23076923};
 
@@ -102,69 +102,3 @@ inline auto linearStressResultsOfTetrahedron = [](auto& nonLinearOperator, auto&
 
   return std::make_tuple(resultRequirements, expectedStress, getVertexPositions(fe));
 };
-
-//
-// auto createLinearStressResults = []<typename NonLinearOperator, typename FiniteElement>(
-//                                      NonLinearOperator& nonLinearOperator, FiniteElement& fe) {
-//   constexpr int dim = FiniteElement::Traits::mydim;
-//
-//   static_assert(std::remove_cvref_t<decltype(fe.localView().tree())>::degree() == dim,
-//                 "The test to check linear stress is only supported with the powerBasis having the same power as the "
-//                 "element dimension");
-//   static_assert(
-//       std::is_same_v<
-//           std::remove_cvref_t<decltype(fe.localView().tree().child(0))>,
-//           Dune::Functions::LagrangeNode<std::remove_cvref_t<decltype(fe.localView().globalBasis().gridView())>, 1>>,
-//       "The test to check linear stress is only supported for a linear Lagrange basis");
-//
-//   const auto& element          = fe.gridElement();
-//   const auto& referenceElement = Dune::referenceElement<double, dim>(element.type());
-//   const int nodes              = referenceElement.size(dim);
-//
-//   Eigen::MatrixXd expectedStress(nodes, dim * (dim + 1) / 2);
-//
-//   auto& displacement = nonLinearOperator.firstParameter();
-//
-//   if (element.type() == Dune::GeometryTypes::simplex(FiniteElement::Traits::mydim)) {
-//     Eigen::Matrix<double, 1, dim*(dim + 1) / 2> constantStresses;
-//     if constexpr (dim == 2) {
-//       displacement << 0, 0, 2, 0, 1, 0;
-//       constantStresses << 2197.80219780, 659.34065934, 384.61538462;
-//       expectedStress << constantStresses, constantStresses, constantStresses;
-//     } else {
-//       displacement << 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0;
-//       constantStresses << 576.92307692, 1346.15384615, 576.92307692, 0, 384.61538462, 769.23076923;
-//       expectedStress << constantStresses, constantStresses, constantStresses, constantStresses;
-//     }
-//   } else if (element.type() == Dune::GeometryTypes::cube(FiniteElement::Traits::mydim)) {
-//     if constexpr (dim == 2) {
-//       displacement << 0, 0, 1, 1, 1, 1, 1, 1;
-//       if constexpr (requires { fe.setEASType(4); }) {
-//         fe.setEASType(4);
-//         expectedStress << 1214.28571429, 1214.28571429, 384.61538462, 1214.28571429, 214.28571429, 384.61538462,
-//             214.28571429, 1214.28571429, 384.61538462, 214.28571429, 214.28571429, 384.61538462;
-//       } else {
-//         expectedStress << 1428.57142857, 1428.57142857, 769.23076923, 1098.90109890, 329.67032967, 384.61538462,
-//             329.67032967, 1098.90109890, 384.61538462, 0, 0, 0;
-//       }
-//     } else {
-//       displacement << 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
-//       expectedStress << 576.92307692, 1346.15384615, 576.92307692, 384.61538462, 0, 384.61538462, 0, 0, 0, 0, 0, 0,
-//           -1346.15384615, 192.30769231, -1346.15384615, 0, -769.23076923, 0, -1346.15384615, -576.92307692,
-//           -576.92307692, 0, -384.61538462, -384.61538462, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -576.92307692,
-//           -576.92307692, -1346.15384615, -384.61538462, -384.61538462, 0, 0, 0, 0, 0, 0, 0;
-//     }
-//   } else
-//     std::cout << "There is no stress test yet implemented for the Element " << Dune::className(fe) << std::endl;
-//
-//   using namespace Ikarus;
-//   auto resultRequirements = ResultRequirements()
-//                                 .insertGlobalSolution(FESolutions::displacement, displacement)
-//                                 .addResultRequest(ResultType::linearStress);
-//
-//   std::vector<typename FiniteElement::GridElementEntityType::Geometry::LocalCoordinate> positions;
-//   for (auto i : std::views::iota(0, nodes))
-//     positions.push_back(referenceElement.position(i, dim));
-//
-//   return std::make_tuple(resultRequirements, expectedStress, positions);
-// };

--- a/tests/src/resultcollection.hh
+++ b/tests/src/resultcollection.hh
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2022 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+#include "testcommon.hh"
+
+#include <ikarus/finiteelements/ferequirements.hh>
+
+template <typename FiniteElement>
+auto getVertexPositions(FiniteElement& fe) {
+  constexpr int dim            = FiniteElement::Traits::mydim;
+  const auto& element          = fe.gridElement();
+  const auto& referenceElement = Dune::referenceElement<double, dim>(element.type());
+  const int nodes              = referenceElement.size(dim);
+
+  std::vector<typename FiniteElement::GridElementEntityType::Geometry::LocalCoordinate> positions;
+  for (auto i : std::views::iota(0, nodes))
+    positions.push_back(referenceElement.position(i, dim));
+
+  return positions;
+}
+
+inline auto linearStressResultsOfSquare = [](auto& nonLinearOperator, auto& fe) {
+  constexpr int nodes      = 4;
+  constexpr int quantities = 3;
+
+  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  if constexpr (requires { fe.setEASType(4); }) {
+    fe.setEASType(4);
+    expectedStress << 1214.28571429, 1214.28571429, 384.61538462, 1214.28571429, 214.28571429, 384.61538462,
+        214.28571429, 1214.28571429, 384.61538462, 214.28571429, 214.28571429, 384.61538462;
+  } else {
+    expectedStress << 1428.57142857, 1428.57142857, 769.23076923, 1098.90109890, 329.67032967, 384.61538462,
+        329.67032967, 1098.90109890, 384.61538462, 0, 0, 0;
+  }
+
+  auto& displacement = nonLinearOperator.firstParameter();
+  displacement << 0, 0, 1, 1, 1, 1, 1, 1;
+
+  using namespace Ikarus;
+  auto resultRequirements = ResultRequirements()
+                                .insertGlobalSolution(FESolutions::displacement, displacement)
+                                .addResultRequest(ResultType::linearStress);
+
+  return std::make_tuple(resultRequirements, expectedStress, getVertexPositions(fe));
+};
+
+inline auto linearStressResultsOfCube = [](auto& nonLinearOperator, auto& fe) {
+  constexpr int nodes      = 8;
+  constexpr int quantities = 6;
+
+  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  expectedStress << 576.92307692, 1346.15384615, 576.92307692, 384.61538462, 0, 384.61538462, 0, 0, 0, 0, 0, 0,
+      -1346.15384615, 192.30769231, -1346.15384615, 0, -769.23076923, 0, -1346.15384615, -576.92307692, -576.92307692,
+      0, -384.61538462, -384.61538462, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -576.92307692, -576.92307692, -1346.15384615,
+      -384.61538462, -384.61538462, 0, 0, 0, 0, 0, 0, 0;
+
+  auto& displacement = nonLinearOperator.firstParameter();
+  displacement << 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+
+  using namespace Ikarus;
+  auto resultRequirements = ResultRequirements()
+                                .insertGlobalSolution(FESolutions::displacement, displacement)
+                                .addResultRequest(ResultType::linearStress);
+
+  return std::make_tuple(resultRequirements, expectedStress, getVertexPositions(fe));
+};
+
+inline auto linearStressResultsOfTriangle = [](auto& nonLinearOperator, auto& fe) {
+  constexpr int nodes      = 3;
+  constexpr int quantities = 3;
+
+  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  expectedStress.rowwise() = Eigen::Matrix<double, 1, quantities>{2197.80219780, 659.34065934, 384.61538462};
+
+  auto& displacement = nonLinearOperator.firstParameter();
+  displacement << 0, 0, 2, 0, 1, 0;
+
+  using namespace Ikarus;
+  auto resultRequirements = ResultRequirements()
+                                .insertGlobalSolution(FESolutions::displacement, displacement)
+                                .addResultRequest(ResultType::linearStress);
+
+  return std::make_tuple(resultRequirements, expectedStress, getVertexPositions(fe));
+};
+
+inline auto linearStressResultsOfTetrahedron = [](auto& nonLinearOperator, auto& fe) {
+  constexpr int nodes      = 4;
+  constexpr int quantities = 6;
+
+  Eigen::Matrix<double, nodes, quantities> expectedStress;
+  expectedStress.rowwise()
+      = Eigen::Matrix<double, 1, quantities>{576.92307692, 1346.15384615, 576.92307692, 0, 384.61538462, 769.23076923};
+
+  auto& displacement = nonLinearOperator.firstParameter();
+  displacement << 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0;
+
+  using namespace Ikarus;
+  auto resultRequirements = ResultRequirements()
+                                .insertGlobalSolution(FESolutions::displacement, displacement)
+                                .addResultRequest(ResultType::linearStress);
+
+  return std::make_tuple(resultRequirements, expectedStress, getVertexPositions(fe));
+};
+
+//
+// auto createLinearStressResults = []<typename NonLinearOperator, typename FiniteElement>(
+//                                      NonLinearOperator& nonLinearOperator, FiniteElement& fe) {
+//   constexpr int dim = FiniteElement::Traits::mydim;
+//
+//   static_assert(std::remove_cvref_t<decltype(fe.localView().tree())>::degree() == dim,
+//                 "The test to check linear stress is only supported with the powerBasis having the same power as the "
+//                 "element dimension");
+//   static_assert(
+//       std::is_same_v<
+//           std::remove_cvref_t<decltype(fe.localView().tree().child(0))>,
+//           Dune::Functions::LagrangeNode<std::remove_cvref_t<decltype(fe.localView().globalBasis().gridView())>, 1>>,
+//       "The test to check linear stress is only supported for a linear Lagrange basis");
+//
+//   const auto& element          = fe.gridElement();
+//   const auto& referenceElement = Dune::referenceElement<double, dim>(element.type());
+//   const int nodes              = referenceElement.size(dim);
+//
+//   Eigen::MatrixXd expectedStress(nodes, dim * (dim + 1) / 2);
+//
+//   auto& displacement = nonLinearOperator.firstParameter();
+//
+//   if (element.type() == Dune::GeometryTypes::simplex(FiniteElement::Traits::mydim)) {
+//     Eigen::Matrix<double, 1, dim*(dim + 1) / 2> constantStresses;
+//     if constexpr (dim == 2) {
+//       displacement << 0, 0, 2, 0, 1, 0;
+//       constantStresses << 2197.80219780, 659.34065934, 384.61538462;
+//       expectedStress << constantStresses, constantStresses, constantStresses;
+//     } else {
+//       displacement << 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0;
+//       constantStresses << 576.92307692, 1346.15384615, 576.92307692, 0, 384.61538462, 769.23076923;
+//       expectedStress << constantStresses, constantStresses, constantStresses, constantStresses;
+//     }
+//   } else if (element.type() == Dune::GeometryTypes::cube(FiniteElement::Traits::mydim)) {
+//     if constexpr (dim == 2) {
+//       displacement << 0, 0, 1, 1, 1, 1, 1, 1;
+//       if constexpr (requires { fe.setEASType(4); }) {
+//         fe.setEASType(4);
+//         expectedStress << 1214.28571429, 1214.28571429, 384.61538462, 1214.28571429, 214.28571429, 384.61538462,
+//             214.28571429, 1214.28571429, 384.61538462, 214.28571429, 214.28571429, 384.61538462;
+//       } else {
+//         expectedStress << 1428.57142857, 1428.57142857, 769.23076923, 1098.90109890, 329.67032967, 384.61538462,
+//             329.67032967, 1098.90109890, 384.61538462, 0, 0, 0;
+//       }
+//     } else {
+//       displacement << 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+//       expectedStress << 576.92307692, 1346.15384615, 576.92307692, 384.61538462, 0, 384.61538462, 0, 0, 0, 0, 0, 0,
+//           -1346.15384615, 192.30769231, -1346.15384615, 0, -769.23076923, 0, -1346.15384615, -576.92307692,
+//           -576.92307692, 0, -384.61538462, -384.61538462, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -576.92307692,
+//           -576.92307692, -1346.15384615, -384.61538462, -384.61538462, 0, 0, 0, 0, 0, 0, 0;
+//     }
+//   } else
+//     std::cout << "There is no stress test yet implemented for the Element " << Dune::className(fe) << std::endl;
+//
+//   using namespace Ikarus;
+//   auto resultRequirements = ResultRequirements()
+//                                 .insertGlobalSolution(FESolutions::displacement, displacement)
+//                                 .addResultRequest(ResultType::linearStress);
+//
+//   std::vector<typename FiniteElement::GridElementEntityType::Geometry::LocalCoordinate> positions;
+//   for (auto i : std::views::iota(0, nodes))
+//     positions.push_back(referenceElement.position(i, dim));
+//
+//   return std::make_tuple(resultRequirements, expectedStress, positions);
+// };

--- a/tests/src/testcommon.hh
+++ b/tests/src/testcommon.hh
@@ -190,7 +190,6 @@ template <typename NonLinearOperator, typename FiniteElement>
                                     const Ikarus::ResultRequirements<>& resultRequirements, const auto& expectedResult,
                                     const auto& evaluationPositions, const std::string& messageIfFailed = "") {
   Eigen::MatrixXd computedResults(expectedResult.rows(), expectedResult.cols());
-  computedResults.setZero();
 
   Ikarus::ResultTypeMap result;
   for (int i = 0; const auto& pos : evaluationPositions) {
@@ -198,9 +197,10 @@ template <typename NonLinearOperator, typename FiniteElement>
     computedResults.row(i++) = result.getSingleResult().second.transpose();
   }
 
-  Dune::TestSuite t("Test of the calulateAt function");
-  const bool isStressCorrect = isApproxSame(computedResults, expectedResult, 1e-8);
-  t.check(isStressCorrect) << "Computed Result for " + Dune::className(fe) + " is not the same as expected result:\n"
+  Dune::TestSuite t("Test of the calulateAt function for " + Dune::className(fe));
+  const bool isResultCorrect = isApproxSame(computedResults, expectedResult, 1e-8);
+  t.check(isResultCorrect) << "Computed Result for " << toString(resultRequirements.getRequestedResult())
+                           << " is not the same as expected result:\n"
                            << "It is:\n"
                            << computedResults << "\nBut should be:\n"
                            << expectedResult << "\n"

--- a/tests/src/testenhancedassumedstrains.cpp
+++ b/tests/src/testenhancedassumedstrains.cpp
@@ -3,6 +3,7 @@
 
 #include <config.h>
 
+#include "resultcollection.hh"
 #include "testeas.hh"
 #include "testfeelement.hh"
 
@@ -35,9 +36,9 @@ int main(int argc, char** argv) {
 
   t.subTest(testFEElement<EASElement>(firstOrderLagrangePrePower3Basis, "EAS", randomlyDistorted,
                                       Dune::ReferenceElements<double, 3>::cube(), checkJacobianFunctor));
-  t.subTest(testFEElement<EASElement>(firstOrderLagrangePrePower2Basis, "EAS", unDistorted,
-                                      Dune::ReferenceElements<double, 2>::cube(), checkLinearStressFunctor,
-                                      checkResultFunctionFunctor));
+  t.subTest(testFEElement<EASElement>(
+      firstOrderLagrangePrePower2Basis, "EAS", unDistorted, Dune::ReferenceElements<double, 2>::cube(),
+      checkCalculateAtFunctorFactory(linearStressResultsOfSquare), checkResultFunctionFunctor));
 
   return t.exit();
 }

--- a/tests/src/testfeelement.hh
+++ b/tests/src/testfeelement.hh
@@ -7,11 +7,9 @@
 
 #include <dune/common/bitsetvector.hh>
 #include <dune/fufem/boundarypatch.hh>
-#include <dune/grid/uggrid.hh>
 
 #include <ikarus/assembler/simpleassemblers.hh>
 #include <ikarus/finiteelements/ferequirements.hh>
-#include <ikarus/io/resultfunction.hh>
 #include <ikarus/linearalgebra/dirichletvalues.hh>
 #include <ikarus/linearalgebra/nonlinearoperator.hh>
 #include <ikarus/utils/basis.hh>
@@ -116,12 +114,6 @@ auto testFEElement(const PreBasis& preBasis, const std::string& elementName, con
   } else
     spdlog::info("No element test functor found for {}", Dune::className<FEElementType>());
 
-  // Trying to instantiate the Result Evaluator @todo this should be done differently
-  if constexpr (gridDim == 2) {
-    auto resReq         = Ikarus::ResultRequirements(requirements).addResultRequest(ResultType::PK2Stress);
-    auto resultFunction = std::make_shared<ResultFunction<FEElementType>>(&fes, resReq);
-  }
-
   return t;
 }
 
@@ -135,10 +127,14 @@ inline auto checkJacobianFunctor = [](auto& nonLinOp, [[maybe_unused]] auto& fe,
   auto subOperator = nonLinOp.template subOperator<1, 2>();
   return checkJacobianOfElement(subOperator);
 };
-inline auto checkLinearStressFunctor
-    = [](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) { return checkLinearStress(nonLinOp, fe); };
-
 inline auto checkResultFunctionFunctor
     = [](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) { return checkResultFunction(nonLinOp, fe); };
 inline auto checkFEByAutoDiffFunctor
     = [](auto& nonLinOp, auto& fe, auto& req) { return checkFEByAutoDiff(nonLinOp, fe, req); };
+
+auto checkCalculateAtFunctorFactory(const auto resultCollectionFunction) {
+  return [=](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) {
+    auto [resultRequirements, expectedStress, positions] = resultCollectionFunction(nonLinOp, fe);
+    return checkCalculateAt(nonLinOp, fe, resultRequirements, expectedStress, positions);
+  };
+}

--- a/tests/src/testfeelement.hh
+++ b/tests/src/testfeelement.hh
@@ -133,7 +133,7 @@ inline auto checkFEByAutoDiffFunctor
     = [](auto& nonLinOp, auto& fe, auto& req) { return checkFEByAutoDiff(nonLinOp, fe, req); };
 
 auto checkCalculateAtFunctorFactory(const auto resultCollectionFunction) {
-  return [=](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) {
+  return [&](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) {
     auto [resultRequirements, expectedStress, positions] = resultCollectionFunction(nonLinOp, fe);
     return checkCalculateAt(nonLinOp, fe, resultRequirements, expectedStress, positions);
   };

--- a/tests/src/testlinearelasticity.cpp
+++ b/tests/src/testlinearelasticity.cpp
@@ -3,6 +3,7 @@
 
 #include <config.h>
 
+#include "resultcollection.hh"
 #include "testfeelement.hh"
 
 #include <dune/common/test/testsuite.hh>
@@ -39,9 +40,9 @@ int main(int argc, char** argv) {
                                                 Dune::ReferenceElements<double, 2>::cube(), checkGradientFunctor,
                                                 checkHessianFunctor, checkJacobianFunctor, checkFEByAutoDiffFunctor));
 
-  t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower2Basis, "LinearElastic", unDistorted,
-                                                Dune::ReferenceElements<double, 2>::cube(), checkLinearStressFunctor,
-                                                checkResultFunctionFunctor));
+  t.subTest(testFEElement<LinearElasticElement>(
+      firstOrderLagrangePrePower2Basis, "LinearElastic", unDistorted, Dune::ReferenceElements<double, 2>::cube(),
+      checkCalculateAtFunctorFactory(linearStressResultsOfSquare), checkResultFunctionFunctor));
 
   // Test simplex 2D
   t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower2Basis, "LinearElastic", randomlyDistorted,
@@ -53,7 +54,7 @@ int main(int argc, char** argv) {
 
   t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower2Basis, "LinearElastic", unDistorted,
                                                 Dune::ReferenceElements<double, 2>::simplex(),
-                                                checkLinearStressFunctor));
+                                                checkCalculateAtFunctorFactory(linearStressResultsOfTriangle)));
 
   // Test cube 3D
   t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower3Basis, "LinearElastic", randomlyDistorted,
@@ -67,13 +68,17 @@ int main(int argc, char** argv) {
                                                 checkGradientFunctor, checkHessianFunctor, checkJacobianFunctor,
                                                 checkFEByAutoDiffFunctor));
 
+  t.subTest(testFEElement<LinearElasticElement>(
+      firstOrderLagrangePrePower3Basis, "LinearElastic", unDistorted, Dune::ReferenceElements<double, 3>::cube(),
+      checkCalculateAtFunctorFactory(linearStressResultsOfCube), checkResultFunctionFunctor));
+
   // Test simplex 3D
   t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower3Basis, "LinearElastic", randomlyDistorted,
                                                 Dune::ReferenceElements<double, 3>::simplex(), checkGradientFunctor,
                                                 checkHessianFunctor, checkJacobianFunctor, checkFEByAutoDiffFunctor));
 
-  t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower3Basis, "LinearElastic", unDistorted,
-                                                Dune::ReferenceElements<double, 3>::simplex(), checkLinearStressFunctor,
-                                                checkResultFunctionFunctor));
+  t.subTest(testFEElement<LinearElasticElement>(
+      firstOrderLagrangePrePower3Basis, "LinearElastic", unDistorted, Dune::ReferenceElements<double, 3>::simplex(),
+      checkCalculateAtFunctorFactory(linearStressResultsOfTetrahedron), checkResultFunctionFunctor));
   return t.exit();
 }


### PR DESCRIPTION
This is a small PR adding a stress test for linear 3D cube elements .
We should discuss for a different PR how and if we want to modify this whole testing framework, maybe storing the expected values in the element formulation or sth like that.

For reference: my calulations come from these notebooks: https://github.tik.uni-stuttgart.de/HenrikJakob/elements-notebooks/tree/main

I might also add a test for 3d cube with EAS tommorow, so we can also add this to this PR