### PR TITLE
Fix Python error in nonlinearelastic test + python KL shell renaming

### DIFF
--- a/ikarus/python/finiteelements/kirchhoffloveshell.hh
+++ b/ikarus/python/finiteelements/kirchhoffloveshell.hh
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "linearelastic.hh"
+
 #include <dune/fufem/boundarypatch.hh>
 #include <dune/functions/functionspacebases/lagrangebasis.hh>
 #include <dune/functions/functionspacebases/powerbasis.hh>
@@ -18,10 +20,8 @@
 #include <ikarus/finiteelements/mechanics/kirchhoffloveshell.hh>
 #include <ikarus/utils/basis.hh>
 
-#include "linearelastic.hh"
-
 namespace Ikarus::Python {
-  
+
   template <class KirchhoffLoveShell, class... options>
   void registerKirchhoffLoveShell(pybind11::handle scope, pybind11::class_<KirchhoffLoveShell, options...> cls) {
     registerElement<false, KirchhoffLoveShell, options...>(scope, cls);
@@ -40,9 +40,11 @@ namespace Ikarus::Python {
             }),
             pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>());
 
-    cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
-                              double thickness) { return new KirchhoffLoveShell(basis, element, emod, nu, thickness); }),
-            pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>());
+    cls.def(
+        pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu, double thickness) {
+          return new KirchhoffLoveShell(basis, element, emod, nu, thickness);
+        }),
+        pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>());
 
     cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
                               double thickness, const LoadFunction volumeLoad, const BoundaryPatch<GridView>& bp,

--- a/ikarus/python/finiteelements/kirchhoffloveshell.hh
+++ b/ikarus/python/finiteelements/kirchhoffloveshell.hh
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2021-2023 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <dune/fufem/boundarypatch.hh>
+#include <dune/functions/functionspacebases/lagrangebasis.hh>
+#include <dune/functions/functionspacebases/powerbasis.hh>
+#include <dune/grid/yaspgrid.hh>
+#include <dune/python/common/typeregistry.hh>
+#include <dune/python/functions/globalbasis.hh>
+#include <dune/python/pybind11/eigen.h>
+#include <dune/python/pybind11/functional.h>
+#include <dune/python/pybind11/pybind11.h>
+#include <dune/python/pybind11/stl.h>
+
+#include <ikarus/finiteelements/ferequirements.hh>
+#include <ikarus/finiteelements/mechanics/kirchhoffloveshell.hh>
+#include <ikarus/utils/basis.hh>
+
+#include "linearelastic.hh"
+
+namespace Ikarus::Python {
+  
+  template <class KirchhoffLoveShell, class... options>
+  void registerKirchhoffLoveShell(pybind11::handle scope, pybind11::class_<KirchhoffLoveShell, options...> cls) {
+    registerElement<false, KirchhoffLoveShell, options...>(scope, cls);
+    using GlobalBasis    = typename KirchhoffLoveShell::Basis;
+    using FlatBasis      = typename KirchhoffLoveShell::FlatBasis;
+    using GridView       = typename GlobalBasis::GridView;
+    using Element        = typename KirchhoffLoveShell::Element;
+    using Traits         = typename KirchhoffLoveShell::Traits;
+    using FErequirements = typename KirchhoffLoveShell::FERequirementType;
+
+    using LoadFunction = std::function<Eigen::Vector<double, Traits::worlddim>(Eigen::Vector<double, Traits::worlddim>,
+                                                                               const double&)>;
+    cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
+                              double thickness, const LoadFunction volumeLoad) {
+              return new KirchhoffLoveShell(basis, element, emod, nu, thickness, volumeLoad);
+            }),
+            pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>());
+
+    cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
+                              double thickness) { return new KirchhoffLoveShell(basis, element, emod, nu, thickness); }),
+            pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>());
+
+    cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
+                              double thickness, const LoadFunction volumeLoad, const BoundaryPatch<GridView>& bp,
+                              const LoadFunction neumannBoundaryLoad) {
+              return new KirchhoffLoveShell(basis, element, emod, nu, thickness, volumeLoad, &bp, neumannBoundaryLoad);
+            }),
+            pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>(), pybind11::keep_alive<1, 8>());
+  }
+
+}  // namespace Ikarus::Python

--- a/ikarus/python/finiteelements/linearelastic.hh
+++ b/ikarus/python/finiteelements/linearelastic.hh
@@ -15,7 +15,6 @@
 #include <dune/python/pybind11/stl.h>
 
 #include <ikarus/finiteelements/ferequirements.hh>
-#include <ikarus/finiteelements/mechanics/kirchhoffloveshell.hh>
 #include <ikarus/finiteelements/mechanics/linearelastic.hh>
 #include <ikarus/utils/basis.hh>
 
@@ -121,36 +120,6 @@ namespace Ikarus::Python {
   template <class LinearElastic, class... options>
   void registerLinearElastic(pybind11::handle scope, pybind11::class_<LinearElastic, options...> cls) {
     registerElement(scope, cls);
-  }
-
-  template <class LinearElastic, class... options>
-  void registerKirchhoffLoveShell(pybind11::handle scope, pybind11::class_<LinearElastic, options...> cls) {
-    registerElement<false, LinearElastic, options...>(scope, cls);
-    using GlobalBasis    = typename LinearElastic::Basis;
-    using FlatBasis      = typename LinearElastic::FlatBasis;
-    using GridView       = typename GlobalBasis::GridView;
-    using Element        = typename LinearElastic::Element;
-    using Traits         = typename LinearElastic::Traits;
-    using FErequirements = typename LinearElastic::FERequirementType;
-
-    using LoadFunction = std::function<Eigen::Vector<double, Traits::worlddim>(Eigen::Vector<double, Traits::worlddim>,
-                                                                               const double&)>;
-    cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
-                              double thickness, const LoadFunction volumeLoad) {
-              return new LinearElastic(basis, element, emod, nu, thickness, volumeLoad);
-            }),
-            pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>());
-
-    cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
-                              double thickness) { return new LinearElastic(basis, element, emod, nu, thickness); }),
-            pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>());
-
-    cls.def(pybind11::init([](const GlobalBasis& basis, const Element& element, double emod, double nu,
-                              double thickness, const LoadFunction volumeLoad, const BoundaryPatch<GridView>& bp,
-                              const LoadFunction neumannBoundaryLoad) {
-              return new LinearElastic(basis, element, emod, nu, thickness, volumeLoad, &bp, neumannBoundaryLoad);
-            }),
-            pybind11::keep_alive<1, 2>(), pybind11::keep_alive<1, 3>(), pybind11::keep_alive<1, 8>());
   }
 
 }  // namespace Ikarus::Python

--- a/ikarus/python/test/nonlinearelastictest.py
+++ b/ikarus/python/test/nonlinearelastictest.py
@@ -126,17 +126,14 @@ if __name__ == "__main__":
     )
     resultd4 = sp.optimize.root(gradient, jac=hess, x0=dRed, tol=1e-10)
 
-    np.set_printoptions(precision=3)
-
     assert np.allclose(resultd.x, resultd2.x, atol=1e-6)
     assert np.allclose(resultd3.x, resultd4.x)
     assert np.all(abs(resultd3.grad) < 1e-8)
     assert np.all(abs(resultd4.fun) < 1e-8)
 
     resReq = ikarus.ResultRequirements()
-    resReq.insertGlobalSolution(
-        iks.FESolutions.displacement, assembler.createFullVector(resultd.x)
-    )
+    fullD = assembler.createFullVector(resultd2.x)
+    resReq.insertGlobalSolution(iks.FESolutions.displacement, fullD)
     resReq.insertParameter(iks.FEParameter.loadfactor, lambdaLoad)
     resReq.addResultRequest(iks.ResultType.PK2Stress)
 

--- a/python/ikarus/finite_elements/__init__.py
+++ b/python/ikarus/finite_elements/__init__.py
@@ -101,7 +101,7 @@ def KirchhoffLoveShell(
     neumannBoundaryLoad=None,
 ):
     generator = MySimpleGenerator("KirchhoffLoveShell", "Ikarus::Python")
-    includes = ["ikarus/python/finiteelements/linearelastic.hh"]
+    includes = ["ikarus/python/finiteelements/kirchhoffloveshell.hh"]
 
     includes += ["ikarus/finiteelements/febases/autodifffe.hh"]
     autodiffWrapper = "AutoDiffFE"


### PR DESCRIPTION
This fixes the bug in the python test also KL shell now has its own file + template arguments are now properly named 