### PR TITLE
Refactor load functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ via `pip install pyikarus` ([#152](https://github.com/ikarus-project/ikarus/pull
 - Added a default adaptive step sizing possibility and refactored loggers ([#193](https://github.com/ikarus-project/ikarus/pull/193))
 - Added a wrapper to fix Dirichlet BCs for Lagrange Nodes ([#222](https://github.com/ikarus-project/ikarus/pull/222))
 - Refactored `getDisplacementFunction` in finite elements ([#223](https://github.com/ikarus-project/ikarus/pull/223))
+- Refactored load functions in finite elements ([#221](https://github.com/ikarus-project/ikarus/pull/221))
 
 - Improve material library and Python bindings ([#186](https://github.com/ikarus-project/ikarus/pull/176)), default e.g.
   `StVenantKirchhoff` is

--- a/ikarus/finiteelements/febases/autodifffe.hh
+++ b/ikarus/finiteelements/febases/autodifffe.hh
@@ -30,12 +30,12 @@ namespace Ikarus {
             bool forceAutoDiff = false>
   class AutoDiffFE : public RealFE_ {
   public:
-    using RealFE            = RealFE_;                                      ///< Type of the base finite element.
-    using Basis             = typename RealFE::Basis;                       ///< Type of the basis.
-    using LocalView         = typename Basis::FlatBasis::LocalView;         ///< Type of the local view.
-    using Traits            = TraitsFromLocalView<LocalView, useEigenRef>;  ///< Type traits for local view.
-    using Element           = typename LocalView::Element;                  ///< Type of the element.
-    using FERequirementType = FERequirementType_;  ///< Type of the Finite Element Requirements.
+    using RealFE            = RealFE_;                               ///< Type of the base finite element.
+    using Basis             = typename RealFE::Basis;                ///< Type of the basis.
+    using LocalView         = typename Basis::FlatBasis::LocalView;  ///< Type of the local view.
+    using Element           = typename LocalView::Element;           ///< Type of the element.
+    using FERequirementType = FERequirementType_;                    ///< Type of the Finite Element Requirements.
+    using Traits            = TraitsFromFE<Basis, FERequirementType_, useEigenRef>;  ///< Type traits for local view.
 
     /**
      * @brief Calculate the matrix associated with the finite element.

--- a/ikarus/finiteelements/febases/autodifffe.hh
+++ b/ikarus/finiteelements/febases/autodifffe.hh
@@ -30,12 +30,12 @@ namespace Ikarus {
             bool forceAutoDiff = false>
   class AutoDiffFE : public RealFE_ {
   public:
-    using RealFE            = RealFE_;                               ///< Type of the base finite element.
-    using Basis             = typename RealFE::Basis;                ///< Type of the basis.
-    using LocalView         = typename Basis::FlatBasis::LocalView;  ///< Type of the local view.
-    using Element           = typename LocalView::Element;           ///< Type of the element.
-    using FERequirementType = FERequirementType_;                    ///< Type of the Finite Element Requirements.
+    using RealFE            = RealFE_;                 ///< Type of the base finite element.
+    using Basis             = typename RealFE::Basis;  ///< Type of the basis.
     using Traits            = TraitsFromFE<Basis, FERequirementType_, useEigenRef>;  ///< Type traits for local view.
+    using LocalView         = typename Traits::LocalView;                            ///< Type of the local view.
+    using Element           = typename Traits::Element;                              ///< Type of the element.
+    using FERequirementType = typename Traits::FERequirementType;  ///< Type of the Finite Element Requirements.
 
     /**
      * @brief Calculate the matrix associated with the finite element.

--- a/ikarus/finiteelements/fehelper.hh
+++ b/ikarus/finiteelements/fehelper.hh
@@ -12,8 +12,7 @@ namespace Ikarus::FEHelper {
   /**
    * @brief Gets the local solution Dune block vector
    *
-   * @tparam FERequirementType Type of the FE requirements.
-   * @tparam LocalView Type of the local view.
+   * @tparam Traits Type of the FE traits.
    * @tparam ScalarType Scalar type for the local solution vector.
    *
    * @param x The global solution vector.
@@ -22,10 +21,10 @@ namespace Ikarus::FEHelper {
    *
    * @return A Dune block vector representing the solution quantities at each node.
    * */
-  template <typename FERequirementType, typename LocalView, typename ScalarType>
-  auto localSolutionBlockVector(const typename FERequirementType::SolutionVectorTypeRaw& x, const LocalView& localView,
+  template <typename Traits, typename ScalarType>
+  auto localSolutionBlockVector(const typename Traits::FERequirementType::SolutionVectorTypeRaw& x,
+                                const typename Traits::LocalView& localView,
                                 const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) {
-    using Traits           = TraitsFromLocalView<LocalView>;
     constexpr int worldDim = Traits::worlddim;
     const auto& fe         = localView.tree().child(0).finiteElement();
     Dune::BlockVector<Dune::RealTuple<ScalarType, worldDim>> localX(fe.size());

--- a/ikarus/finiteelements/mechanics/CMakeLists.txt
+++ b/ikarus/finiteelements/mechanics/CMakeLists.txt
@@ -3,6 +3,6 @@
 add_subdirectory(materials)
 # install headers
 install(FILES nonlinearelastic.hh enhancedassumedstrains.hh linearelastic.hh materials.hh
-              kirchhoffloveshell.hh membranestrains.hh
+              kirchhoffloveshell.hh membranestrains.hh loads.hh
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/mechanics
 )

--- a/ikarus/finiteelements/mechanics/CMakeLists.txt
+++ b/ikarus/finiteelements/mechanics/CMakeLists.txt
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 add_subdirectory(materials)
 # install headers
-install(FILES nonlinearelastic.hh enhancedassumedstrains.hh linearelastic.hh materials.hh
-              kirchhoffloveshell.hh membranestrains.hh loads.hh
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/mechanics
+install(
+  FILES nonlinearelastic.hh
+        enhancedassumedstrains.hh
+        linearelastic.hh
+        materials.hh
+        kirchhoffloveshell.hh
+        membranestrains.hh
+        loads.hh
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/mechanics
 )

--- a/ikarus/finiteelements/mechanics/CMakeLists.txt
+++ b/ikarus/finiteelements/mechanics/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
 # SPDX-License-Identifier: LGPL-3.0-or-later
+add_subdirectory(loads)
 add_subdirectory(materials)
 # install headers
 install(

--- a/ikarus/finiteelements/mechanics/enhancedassumedstrains.hh
+++ b/ikarus/finiteelements/mechanics/enhancedassumedstrains.hh
@@ -471,7 +471,7 @@ namespace Ikarus {
 
       const auto& par           = req.getFERequirements();
       const auto C              = DisplacementBasedElement::materialTangentFunction(req.getFERequirements());
-      const auto& numberOfNodes = DisplacementBasedElement::numberOfNodes;
+      const auto& numberOfNodes = DisplacementBasedElement::numberOfNodes();
       auto uFunction            = DisplacementBasedElement::displacementFunction(par);
       const auto disp           = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
 
@@ -503,7 +503,7 @@ namespace Ikarus {
      * @param numberOfEASParameters_ The number of EAS parameters
      */
     void setEASType(int numberOfEASParameters_) {
-      const auto& numberOfNodes = DisplacementBasedElement::numberOfNodes;
+      const auto& numberOfNodes = DisplacementBasedElement::numberOfNodes();
       if (not((numberOfNodes == 4 and Traits::mydim == 2) or (numberOfNodes == 8 and Traits::mydim == 3))
           and (not isDisplacementBased()))
         DUNE_THROW(Dune::NotImplemented, "EAS only supported for Q1 or H1 elements");
@@ -562,7 +562,7 @@ namespace Ikarus {
       using namespace Dune;
       const auto uFunction      = DisplacementBasedElement::displacementFunction(par, dx);
       auto strainFunction       = DisplacementBasedElement::strainFunction(par, dx);
-      const auto& numberOfNodes = DisplacementBasedElement::numberOfNodes;
+      const auto& numberOfNodes = DisplacementBasedElement::numberOfNodes();
       const auto disp           = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
 
       using namespace Dune::DerivativeDirections;
@@ -611,7 +611,7 @@ namespace Ikarus {
       auto strainFunction      = DisplacementBasedElement::strainFunction(par);
       const auto C             = DisplacementBasedElement::materialTangentFunction(par);
       const auto geo           = localView().element().geometry();
-      const auto numberOfNodes = DisplacementBasedElement::numberOfNodes;
+      const auto numberOfNodes = DisplacementBasedElement::numberOfNodes();
       DMat.setZero();
       LMat.setZero(enhancedStrainSize, localView().size());
       for (const auto& [gpIndex, gp] : strainFunction.viewOverIntegrationPoints()) {

--- a/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
+++ b/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
@@ -104,8 +104,8 @@ namespace Ikarus {
                        const BoundaryPatch<GridView>* p_neumannBoundary = nullptr,
                        NeumannBoundaryLoad p_neumannBoundaryLoad        = {})
         : BasePowerFE(globalBasis.flat(), element),
-          VolumeType(*this, p_volumeLoad),
-          TractionType(*this, p_neumannBoundary, p_neumannBoundaryLoad),
+          VolumeType(p_volumeLoad),
+          TractionType(p_neumannBoundary, p_neumannBoundaryLoad),
           emod_{emod},
           nu_{nu},
           thickness_{thickness} {

--- a/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
+++ b/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
@@ -354,10 +354,10 @@ namespace Ikarus {
       const auto uFunction = displacementFunction(par, dx);
       const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
       ScalarType energy    = 0.0;
-        const auto disp           = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
-        Eigen::VectorX<ScalarType> force;
-        force.setZero(numberOfNodes * worldDim);
-        Loads loads(*this);
+      const auto disp      = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
+      Eigen::VectorX<ScalarType> force;
+      force.setZero(numberOfNodes * worldDim);
+      Loads loads(*this);
 
       for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
         const auto [C, epsV, kappaV, j, J, h, H, a3N, a3]
@@ -368,16 +368,16 @@ namespace Ikarus {
         energy += (membraneEnergy + bendingEnergy) * geo_->integrationElement(gp.position()) * gp.weight();
       }
 
-        // External forces volume forces over the domain
-        if (volumeLoad) loads.volume(par, force, dx);
-        energy += static_cast<ScalarType>(force.transpose() * disp);
-        force.setZero();
+      // External forces volume forces over the domain
+      if (volumeLoad) loads.volume(par, force, dx);
+      energy += static_cast<ScalarType>(force.transpose() * disp);
+      force.setZero();
 
-        // line or surface loads, i.e., neumann boundary
-        if (not neumannBoundary and not neumannBoundaryLoad) return energy;
-        loads.traction(par, neumannBoundary, force, dx);
+      // line or surface loads, i.e., neumann boundary
+      if (not neumannBoundary and not neumannBoundaryLoad) return energy;
+      loads.traction(par, neumannBoundary, force, dx);
 
-        energy += static_cast<ScalarType>(force.transpose() * disp);
+      energy += static_cast<ScalarType>(force.transpose() * disp);
       return energy;
     }
 

--- a/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
+++ b/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
@@ -49,6 +49,7 @@ namespace Ikarus {
     using LocalView              = typename Traits::LocalView;
     using Geometry               = typename Traits::Geometry;
     using GridView               = typename Traits::GridView;
+    using Element                = typename Traits::Element;
     using BasePowerFE            = PowerBasisFE<FlatBasis>;  // Handles globalIndices function
     using ResultRequirementsType = ResultRequirements<FERequirementType>;
     using VolumeType             = Volume<KirchhoffLoveShell<Basis_, FERequirements_, useEigenRef>, Traits>;

--- a/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
+++ b/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
@@ -148,7 +148,7 @@ namespace Ikarus {
       return uFunction;
     }
 
-    std::shared_ptr<const Geometry> geometry() const { return geo_; }
+    const Geometry& geometry() const { return *geo_; }
     [[nodiscard]] size_t numberOfNodes() const { return numberOfNodes_; }
     [[nodiscard]] int order() const { return order_; }
 

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -80,8 +80,8 @@ namespace Ikarus {
                   VolumeLoad p_volumeLoad = {}, const BoundaryPatch<GridView>* p_neumannBoundary = nullptr,
                   NeumannBoundaryLoad p_neumannBoundaryLoad = {})
         : BaseDisp(globalBasis.flat(), element),
-          VolumeType(*this, p_volumeLoad),
-          TractionType(*this, p_neumannBoundary, p_neumannBoundaryLoad),
+          VolumeType(p_volumeLoad),
+          TractionType(p_neumannBoundary, p_neumannBoundaryLoad),
           emod_{emod},
           nu_{nu} {
       this->localView().bind(element);

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -154,7 +154,7 @@ namespace Ikarus {
       return [&]([[maybe_unused]] auto gp) { return materialTangent(); };
     }
 
-    std::shared_ptr<const Geometry> geometry() const { return geo_; }
+    const Geometry& geometry() const { return *geo_; }
     [[nodiscard]] size_t numberOfNodes() const { return numberOfNodes_; }
     [[nodiscard]] int order() const { return order_; }
 

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -242,7 +242,7 @@ namespace Ikarus {
       using namespace Dune;
       Eigen::VectorX<ScalarType> force;
       force.setZero(numberOfNodes * worldDim);
-        const auto disp           = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
+      const auto disp = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
 
       const auto C = materialTangent();
 

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -24,6 +24,7 @@
 #  include <ikarus/finiteelements/febases/powerbasisfe.hh>
 #  include <ikarus/finiteelements/fehelper.hh>
 #  include <ikarus/finiteelements/ferequirements.hh>
+#  include <ikarus/finiteelements/mechanics/loads.hh>
 #  include <ikarus/finiteelements/mechanics/materials.hh>
 #  include <ikarus/finiteelements/physicshelper.hh>
 #  include <ikarus/utils/defaultfunctions.hh>
@@ -239,62 +240,42 @@ namespace Ikarus {
       const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
+      Eigen::VectorX<ScalarType> force;
+      force.setZero(numberOfNodes * worldDim);
+        const auto disp           = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
 
       const auto C = materialTangent();
 
       ScalarType energy = 0.0;
+      Loads loads(*this);
       for (const auto& [gpIndex, gp] : eps.viewOverIntegrationPoints()) {
         const auto EVoigt = eps.evaluate(gpIndex, on(gridElement));
-
         energy += (0.5 * EVoigt.dot(C * EVoigt)) * geo_->integrationElement(gp.position()) * gp.weight();
       }
 
       // External forces volume forces over the domain
-      if (volumeLoad) {
-        for (const auto& [gpIndex, gp] : eps.viewOverIntegrationPoints()) {
-          const auto uVal                              = uFunction.evaluate(gpIndex);
-          Eigen::Vector<double, Traits::worlddim> fext = volumeLoad(geo_->global(gp.position()), lambda);
-          energy -= uVal.dot(fext) * geo_->integrationElement(gp.position()) * gp.weight();
-        }
-      }
+      if (volumeLoad) loads.volume(par, force, dx);
+      energy += static_cast<ScalarType>(force.transpose() * disp);
+      force.setZero();
 
       // line or surface loads, i.e., neumann boundary
       if (not neumannBoundary and not neumannBoundaryLoad) return energy;
+      loads.traction(par, neumannBoundary, force, dx);
 
-      auto element = this->localView().element();
-      for (auto&& intersection : intersections(neumannBoundary->gridView(), element)) {
-        if (not neumannBoundary->contains(intersection)) continue;
-
-        const auto& quadLine = Dune::QuadratureRules<double, myDim - 1>::rule(intersection.type(), order);
-
-        for (const auto& curQuad : quadLine) {
-          // Local position of the quadrature point
-          const Dune::FieldVector<double, myDim>& quadPos = intersection.geometryInInside().global(curQuad.position());
-
-          const double integrationElement = intersection.geometry().integrationElement(curQuad.position());
-
-          // The value of the local function
-          const auto uVal = uFunction.evaluate(quadPos);
-
-          // Value of the Neumann data at the current position
-          auto neumannValue = neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
-
-          energy -= neumannValue.dot(uVal) * curQuad.weight() * integrationElement;
-        }
-      }
+      energy += static_cast<ScalarType>(force.transpose() * disp);
       return energy;
     }
 
     template <typename ScalarType>
     void calculateVectorImpl(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
                              const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
-      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
-      const auto uFunction = displacementFunction(par, dx);
-      const auto eps       = strainFunction(par, dx);
+      const auto eps = getStrainFunction(par, dx);
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
 
-      const auto C = materialTangent();
+      const auto C   = materialTangent();
+      const auto geo = this->localView().element().geometry();
+      Loads loads(*this);
 
       // Internal forces
       for (const auto& [gpIndex, gp] : eps.viewOverIntegrationPoints()) {
@@ -307,41 +288,11 @@ namespace Ikarus {
       }
 
       // External forces volume forces over the domain
-      if (volumeLoad) {
-        for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
-          Eigen::Vector<double, Traits::worlddim> fext = volumeLoad(geo_->global(gp.position()), lambda);
-          for (size_t i = 0; i < numberOfNodes; ++i) {
-            const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
-            force.template segment<myDim>(myDim * i)
-                -= udCi * fext * geo_->integrationElement(gp.position()) * gp.weight();
-          }
-        }
-      }
+      if (volumeLoad) loads.volume(par, force, dx);
 
       // External forces, boundary forces, i.e., at the Neumann boundary
-      if (not neumannBoundary) return;
-      auto element = this->localView().element();
-      for (auto&& intersection : intersections(neumannBoundary->gridView(), element)) {
-        if (not neumannBoundary->contains(intersection)) continue;
-
-        // Integration rule along the boundary
-        const auto& quadLine = Dune::QuadratureRules<double, myDim - 1>::rule(intersection.type(), order);
-
-        for (const auto& curQuad : quadLine) {
-          const Dune::FieldVector<double, myDim>& quadPos = intersection.geometryInInside().global(curQuad.position());
-
-          const double integrationElement = intersection.geometry().integrationElement(curQuad.position());
-
-          // The value of the local function wrt the i-th coeff
-          for (size_t i = 0; i < numberOfNodes; ++i) {
-            const auto udCi = uFunction.evaluateDerivative(quadPos, wrt(coeff(i)));
-
-            // Value of the Neumann data at the current position
-            auto neumannValue = neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
-            force.template segment<myDim>(myDim * i) -= udCi * neumannValue * curQuad.weight() * integrationElement;
-          }
-        }
-      }
+      if (not neumannBoundary and not neumannBoundaryLoad) return;
+      loads.traction(par, neumannBoundary, force, dx);
     }
   };
 }  // namespace Ikarus

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -269,12 +269,11 @@ namespace Ikarus {
     template <typename ScalarType>
     void calculateVectorImpl(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
                              const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
-      const auto eps = getStrainFunction(par, dx);
+      const auto eps = strainFunction(par, dx);
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
 
-      const auto C   = materialTangent();
-      const auto geo = this->localView().element().geometry();
+      const auto C = materialTangent();
       Loads loads(*this);
 
       // Internal forces

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -55,6 +55,7 @@ namespace Ikarus {
     using LocalView              = typename Traits::LocalView;
     using Geometry               = typename Traits::Geometry;
     using GridView               = typename Traits::GridView;
+    using Element                = typename Traits::Element;
     using ResultRequirementsType = ResultRequirements<FERequirementType>;
     using BaseDisp               = PowerBasisFE<FlatBasis>;  // Handles globalIndices function
     using VolumeType             = Volume<LinearElastic<Basis_, FERequirements_, useEigenRef>, Traits>;

--- a/ikarus/finiteelements/mechanics/loads.hh
+++ b/ikarus/finiteelements/mechanics/loads.hh
@@ -21,9 +21,9 @@ namespace Ikarus {
                 const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
-      const auto uFunction           = ele.displacementFunction(par, dx);
-      const auto geo                 = ele.localView().element().geometry();
-      const auto& lambda             = par.getParameter(Ikarus::FEParameter::loadfactor);
+      const auto uFunction = ele.displacementFunction(par, dx);
+      const auto geo       = ele.localView().element().geometry();
+      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
       for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
         const Eigen::Vector<double, worldDim> fext = ele.volumeLoad(geo.global(gp.position()), lambda);
         const double intElement                    = geo.integrationElement(gp.position()) * gp.weight();
@@ -40,9 +40,9 @@ namespace Ikarus {
                   const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
-      const auto& lambda             = par.getParameter(Ikarus::FEParameter::loadfactor);
-      const auto uFunction           = ele.displacementFunction(par, dx);
-      auto element                   = ele.localView().element();
+      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
+      const auto uFunction = ele.displacementFunction(par, dx);
+      auto element         = ele.localView().element();
       for (auto&& intersection : intersections(tractionBoundary->gridView(), element)) {
         if (not tractionBoundary->contains(intersection)) continue;
 
@@ -58,8 +58,7 @@ namespace Ikarus {
             const auto udCi = uFunction.evaluateDerivative(quadPos, wrt(coeff(i)));
 
             /// Value of the Neumann data at the current position
-            auto neumannValue
-                = ele.neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
+            auto neumannValue = ele.neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
             force.template segment<worldDim>(worldDim * i) -= udCi * neumannValue * curQuad.weight() * intElement;
           }
         }

--- a/ikarus/finiteelements/mechanics/loads.hh
+++ b/ikarus/finiteelements/mechanics/loads.hh
@@ -21,11 +21,11 @@ namespace Ikarus {
                 const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
-      const auto [uFunction, uNodes] = ele.getDisplacementFunction(par, dx);
+      const auto uFunction           = ele.displacementFunction(par, dx);
       const auto geo                 = ele.localView().element().geometry();
       const auto& lambda             = par.getParameter(Ikarus::FEParameter::loadfactor);
       for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
-        const Eigen::Vector<double, worldDim> fext = ele.volumeLoad(toEigen(geo.global(gp.position())), lambda);
+        const Eigen::Vector<double, worldDim> fext = ele.volumeLoad(geo.global(gp.position()), lambda);
         const double intElement                    = geo.integrationElement(gp.position()) * gp.weight();
         for (size_t i = 0; i < ele.numberOfNodes; ++i) {
           const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
@@ -41,7 +41,7 @@ namespace Ikarus {
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
       const auto& lambda             = par.getParameter(Ikarus::FEParameter::loadfactor);
-      const auto [uFunction, uNodes] = ele.getDisplacementFunction(par, dx);
+      const auto uFunction           = ele.displacementFunction(par, dx);
       auto element                   = ele.localView().element();
       for (auto&& intersection : intersections(tractionBoundary->gridView(), element)) {
         if (not tractionBoundary->contains(intersection)) continue;
@@ -59,7 +59,7 @@ namespace Ikarus {
 
             /// Value of the Neumann data at the current position
             auto neumannValue
-                = ele.neumannBoundaryLoad(toEigen(intersection.geometry().global(curQuad.position())), lambda);
+                = ele.neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
             force.template segment<worldDim>(worldDim * i) -= udCi * neumannValue * curQuad.weight() * intElement;
           }
         }

--- a/ikarus/finiteelements/mechanics/loads.hh
+++ b/ikarus/finiteelements/mechanics/loads.hh
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+namespace Ikarus {
+  template <typename DisplacementBasedElement>
+  class Loads {
+  public:
+    using Traits                  = typename DisplacementBasedElement::Traits;
+    using FERequirementType       = typename DisplacementBasedElement::FERequirementType;
+    static constexpr int myDim    = Traits::mydim;
+    static constexpr int worldDim = Traits::worlddim;
+
+    explicit Loads(const DisplacementBasedElement p_ele) : ele{p_ele} {
+      order = 2 * ele.localView().tree().child(0).finiteElement().localBasis().order();
+    }
+
+    template <typename ScalarType>
+    void volume(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
+                const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
+      using namespace Dune::DerivativeDirections;
+      using namespace Dune;
+      const auto [uFunction, uNodes] = ele.getDisplacementFunction(par, dx);
+      const auto geo                 = ele.localView().element().geometry();
+      const auto& lambda             = par.getParameter(Ikarus::FEParameter::loadfactor);
+      for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
+        const Eigen::Vector<double, worldDim> fext = ele.volumeLoad(toEigen(geo.global(gp.position())), lambda);
+        const double intElement                    = geo.integrationElement(gp.position()) * gp.weight();
+        for (size_t i = 0; i < ele.numberOfNodes; ++i) {
+          const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
+          force.template segment<worldDim>(worldDim * i) -= udCi * fext * intElement;
+        }
+      }
+    }
+
+    template <typename ScalarType, typename BoundaryType>
+    void traction(const FERequirementType& par, const BoundaryType& tractionBoundary,
+                  typename Traits::template VectorType<ScalarType> force,
+                  const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
+      using namespace Dune::DerivativeDirections;
+      using namespace Dune;
+      const auto& lambda             = par.getParameter(Ikarus::FEParameter::loadfactor);
+      const auto [uFunction, uNodes] = ele.getDisplacementFunction(par, dx);
+      auto element                   = ele.localView().element();
+      for (auto&& intersection : intersections(tractionBoundary->gridView(), element)) {
+        if (not tractionBoundary->contains(intersection)) continue;
+
+        /// Integration rule along the boundary
+        const auto& quadLine = Dune::QuadratureRules<double, myDim - 1>::rule(intersection.type(), order);
+
+        for (const auto& curQuad : quadLine) {
+          const Dune::FieldVector<double, myDim>& quadPos = intersection.geometryInInside().global(curQuad.position());
+          const double intElement = intersection.geometry().integrationElement(curQuad.position());
+
+          /// The value of the local function wrt the i-th coeff
+          for (size_t i = 0; i < ele.numberOfNodes; ++i) {
+            const auto udCi = uFunction.evaluateDerivative(quadPos, wrt(coeff(i)));
+
+            /// Value of the Neumann data at the current position
+            auto neumannValue
+                = ele.neumannBoundaryLoad(toEigen(intersection.geometry().global(curQuad.position())), lambda);
+            force.template segment<worldDim>(worldDim * i) -= udCi * neumannValue * curQuad.weight() * intElement;
+          }
+        }
+      }
+    }
+
+  private:
+    DisplacementBasedElement ele;
+    int order{};
+  };
+}  // namespace Ikarus

--- a/ikarus/finiteelements/mechanics/loads.hh
+++ b/ikarus/finiteelements/mechanics/loads.hh
@@ -1,9 +1,23 @@
 // SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+/**
+ * @file loads.hh
+ * @brief Definition of the Loads class for application of loads for finite element analysis.
+ * @ingroup mechanics
+ */
+
 #pragma once
 
 namespace Ikarus {
+
+  /**
+   * @brief Loads class represents different types of loads that can be applied.
+   *
+   * @ingroup mechanics
+   *
+   * @tparam DisplacementBasedElement The type of the displacement-based finite element.
+   */
   template <typename DisplacementBasedElement>
   class Loads {
   public:
@@ -12,10 +26,23 @@ namespace Ikarus {
     static constexpr int myDim    = Traits::mydim;
     static constexpr int worldDim = Traits::worlddim;
 
+    /**
+     * @brief Constructor for the Loads class.
+     *
+     * @param p_ele The element on which the load is applied.
+     */
     explicit Loads(const DisplacementBasedElement p_ele) : ele{p_ele} {
       order = 2 * ele.localView().tree().child(0).finiteElement().localBasis().order();
     }
 
+    /**
+     * @brief Applies the distributed volume loads on the element domain.
+     *
+     * @tparam ScalarType The scalar type for the force vector.
+     * @param par The FERequirementType object.
+     * @param force The force vector to be updated.
+     * @param dx Optional displacement vector.
+     */
     template <typename ScalarType>
     void volume(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
                 const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
@@ -34,6 +61,16 @@ namespace Ikarus {
       }
     }
 
+    /**
+     * @brief Applies the distributed traction loads on the element boundary.
+     *
+     * @tparam ScalarType The scalar type for the force vector.
+     * @tparam BoundaryType The type for the traction boundary.
+     * @param par The FERequirementType object.
+     * @param tractionBoundary The element boundary where traction load is applied.
+     * @param force The force vector to be updated.
+     * @param dx Optional displacement vector.
+     */
     template <typename ScalarType, typename BoundaryType>
     void traction(const FERequirementType& par, const BoundaryType& tractionBoundary,
                   typename Traits::template VectorType<ScalarType> force,

--- a/ikarus/finiteelements/mechanics/loads.hh
+++ b/ikarus/finiteelements/mechanics/loads.hh
@@ -3,107 +3,11 @@
 
 /**
  * @file loads.hh
- * @brief Definition of the Loads class for application of loads for finite element analysis.
- * @ingroup mechanics
+ * @brief Header file for types of loads in Ikarus finite element mechanics.
+ * @ingroup  mechanics
  */
 
 #pragma once
 
-namespace Ikarus {
-
-  /**
-   * @brief Loads class represents different types of loads that can be applied.
-   *
-   * @ingroup mechanics
-   *
-   * @tparam DisplacementBasedElement The type of the displacement-based finite element.
-   */
-  template <typename DisplacementBasedElement>
-  class Loads {
-  public:
-    using Traits                  = typename DisplacementBasedElement::Traits;
-    using FERequirementType       = typename DisplacementBasedElement::FERequirementType;
-    static constexpr int myDim    = Traits::mydim;
-    static constexpr int worldDim = Traits::worlddim;
-
-    /**
-     * @brief Constructor for the Loads class.
-     *
-     * @param p_ele The element on which the load is applied.
-     */
-    explicit Loads(const DisplacementBasedElement p_ele) : ele{p_ele} {
-      order = 2 * ele.localView().tree().child(0).finiteElement().localBasis().order();
-    }
-
-    /**
-     * @brief Applies the distributed volume loads on the element domain.
-     *
-     * @tparam ScalarType The scalar type for the force vector.
-     * @param par The FERequirementType object.
-     * @param force The force vector to be updated.
-     * @param dx Optional displacement vector.
-     */
-    template <typename ScalarType>
-    void volume(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
-                const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
-      using namespace Dune::DerivativeDirections;
-      using namespace Dune;
-      const auto uFunction = ele.displacementFunction(par, dx);
-      const auto geo       = ele.localView().element().geometry();
-      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
-      for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
-        const Eigen::Vector<double, worldDim> fext = ele.volumeLoad(geo.global(gp.position()), lambda);
-        const double intElement                    = geo.integrationElement(gp.position()) * gp.weight();
-        for (size_t i = 0; i < ele.numberOfNodes; ++i) {
-          const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
-          force.template segment<worldDim>(worldDim * i) -= udCi * fext * intElement;
-        }
-      }
-    }
-
-    /**
-     * @brief Applies the distributed traction loads on the element boundary.
-     *
-     * @tparam ScalarType The scalar type for the force vector.
-     * @tparam BoundaryType The type for the traction boundary.
-     * @param par The FERequirementType object.
-     * @param tractionBoundary The element boundary where traction load is applied.
-     * @param force The force vector to be updated.
-     * @param dx Optional displacement vector.
-     */
-    template <typename ScalarType, typename BoundaryType>
-    void traction(const FERequirementType& par, const BoundaryType& tractionBoundary,
-                  typename Traits::template VectorType<ScalarType> force,
-                  const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) {
-      using namespace Dune::DerivativeDirections;
-      using namespace Dune;
-      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
-      const auto uFunction = ele.displacementFunction(par, dx);
-      auto element         = ele.localView().element();
-      for (auto&& intersection : intersections(tractionBoundary->gridView(), element)) {
-        if (not tractionBoundary->contains(intersection)) continue;
-
-        /// Integration rule along the boundary
-        const auto& quadLine = Dune::QuadratureRules<double, myDim - 1>::rule(intersection.type(), order);
-
-        for (const auto& curQuad : quadLine) {
-          const Dune::FieldVector<double, myDim>& quadPos = intersection.geometryInInside().global(curQuad.position());
-          const double intElement = intersection.geometry().integrationElement(curQuad.position());
-
-          /// The value of the local function wrt the i-th coeff
-          for (size_t i = 0; i < ele.numberOfNodes; ++i) {
-            const auto udCi = uFunction.evaluateDerivative(quadPos, wrt(coeff(i)));
-
-            /// Value of the Neumann data at the current position
-            auto neumannValue = ele.neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
-            force.template segment<worldDim>(worldDim * i) -= udCi * neumannValue * curQuad.weight() * intElement;
-          }
-        }
-      }
-    }
-
-  private:
-    DisplacementBasedElement ele;
-    int order{};
-  };
-}  // namespace Ikarus
+#include <ikarus/finiteelements/mechanics/loads/traction.hh>
+#include <ikarus/finiteelements/mechanics/loads/volume.hh>

--- a/ikarus/finiteelements/mechanics/loads/CMakeLists.txt
+++ b/ikarus/finiteelements/mechanics/loads/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# install headers
+install(FILES volume.hh traction.hh
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/mechanics/loads
+)

--- a/ikarus/finiteelements/mechanics/loads/traction.hh
+++ b/ikarus/finiteelements/mechanics/loads/traction.hh
@@ -45,31 +45,45 @@ namespace Ikarus {
     }
 
     /**
-     * @brief Const accessor to the underlying displacement-based finite element (CRTP).
+     * @brief Calculate the scalar value.
      *
-     * @return Const reference to the underlying displacement-based finite element.
+     * Calculates the scalar value based on the given FERequirements.
+     *
+     * @param req The FERequirements.
+     * @return The calculated scalar value.
      */
-    constexpr const DisplacementBasedElement& dbElement() const {
-      return static_cast<DisplacementBasedElement const&>(*this);
-    }
+    double calculateScalar(const FERequirementType& req) const { return calculateScalarImpl<double>(req); }
 
     /**
-     * @brief Calculates the scalar energy for the given traction load.
+     * @brief Calculate the vector associated with the given FERequirementType.
      *
-     * @tparam ScalarType The scalar type for the energy.
-     *
-     * @param par The FERequirementType object.
-     * @param dx Optional displacement vector.
-     * @return The scalar energy.
+     * @tparam ScalarType The scalar type for the calculation.
+     * @param req The FERequirementType object specifying the requirements for the calculation.
+     * @param force The vector to store the calculated result.
      */
+    void calculateVector(const FERequirementType& req, typename Traits::template VectorType<> force) const {
+      calculateVectorImpl<double>(req, force);
+    }
+    /**
+     * @brief Calculate the matrix associated with the given FERequirementType.
+     *
+     * @tparam ScalarType The scalar type for the calculation.
+     * @param req The FERequirementType object specifying the requirements for the calculation.
+     * @param K The matrix to store the calculated result.
+     */
+    void calculateMatrix(const FERequirementType& req, typename Traits::template MatrixType<> K) const {
+      calculateMatrixImpl<double>(req, K);
+    }
+
+  protected:
     template <typename ScalarType>
-    auto calculateScalar(const FERequirementType& par,
-                         const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const -> ScalarType {
-      const auto uFunction = dbElement().displacementFunction(par, dx);
+    auto calculateScalarImpl(const FERequirementType& par, const std::optional<const Eigen::VectorX<ScalarType>>& dx
+                                                           = std::nullopt) const -> ScalarType {
+      if (not neumannBoundary and not neumannBoundaryLoad) return 0.0;
       ScalarType energy    = 0.0;
+      const auto uFunction = dbElement().displacementFunction(par, dx);
       const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
-      auto element         = dbElement().localView().element();
-      if (not neumannBoundary and not neumannBoundaryLoad) return energy;
+      auto& element        = dbElement().localView().element();
 
       for (auto&& intersection : intersections(neumannBoundary->gridView(), element)) {
         if (not neumannBoundary->contains(intersection)) continue;
@@ -94,24 +108,15 @@ namespace Ikarus {
       return energy;
     }
 
-    /**
-     * @brief Calculates the force vector for the given traction load.
-     *
-     * @tparam ScalarType The scalar type for the force vector.
-     *
-     * @param par The FERequirementType object.
-     * @param force The force vector to be updated.
-     * @param dx Optional displacement vector.
-     */
     template <typename ScalarType>
-    void calculateVector(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
-                         const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) const {
+    void calculateVectorImpl(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
+                             const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) const {
+      if (not neumannBoundary and not neumannBoundaryLoad) return;
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
       const auto uFunction = dbElement().displacementFunction(par, dx);
       const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
-      auto element         = dbElement().localView().element();
-      if (not neumannBoundary and not neumannBoundaryLoad) return;
+      auto& element        = dbElement().localView().element();
 
       for (auto&& intersection : intersections(neumannBoundary->gridView(), element)) {
         if (not neumannBoundary->contains(intersection)) continue;
@@ -135,22 +140,22 @@ namespace Ikarus {
       }
     }
 
-    /**
-     * @brief Calculates the matrix stiffness for the given traction load.
-     *
-     * @tparam ScalarType The scalar type for the stiffness matrix.
-     *
-     * @param par The FERequirementType object.
-     * @param K Matrix to store the calculated stiffness.
-     * @param dx Optional displacement vector.
-     */
     template <typename ScalarType>
-    void calculateMatrix(const FERequirementType& par, typename Traits::template MatrixType<> K,
-                         const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {}
+    void calculateMatrixImpl(const FERequirementType& par, typename Traits::template MatrixType<> K,
+                             const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {}
 
   private:
     std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
         neumannBoundaryLoad;
     const BoundaryPatch<GridView>* neumannBoundary;
+
+    /**
+     * @brief Const accessor to the underlying displacement-based finite element (CRTP).
+     *
+     * @return Const reference to the underlying displacement-based finite element.
+     */
+    constexpr const DisplacementBasedElement& dbElement() const {
+      return static_cast<DisplacementBasedElement const&>(*this);
+    }
   };
 }  // namespace Ikarus

--- a/ikarus/finiteelements/mechanics/loads/traction.hh
+++ b/ikarus/finiteelements/mechanics/loads/traction.hh
@@ -30,6 +30,7 @@ namespace Ikarus {
     /**
      * @brief Constructor for the Loads class.
      *
+     * @tparam NeumannBoundaryLoad The type for the Neumann boundary load function.
      * @param p_neumannBoundary Neumann boundary patch.
      * @param p_neumannBoundaryLoad Neumann boundary load function.
      */
@@ -53,7 +54,9 @@ namespace Ikarus {
     }
 
     /**
-     * @brief Calculates the scalar energy for the given FERequirementType.
+     * @brief Calculates the scalar energy for the given traction load.
+     *
+     * @tparam ScalarType The scalar type for the energy.
      *
      * @param par The FERequirementType object.
      * @param dx Optional displacement vector.
@@ -92,9 +95,10 @@ namespace Ikarus {
     }
 
     /**
-     * @brief Applies the distributed traction loads on the element boundary.
+     * @brief Calculates the force vector for the given traction load.
      *
      * @tparam ScalarType The scalar type for the force vector.
+     *
      * @param par The FERequirementType object.
      * @param force The force vector to be updated.
      * @param dx Optional displacement vector.
@@ -132,7 +136,9 @@ namespace Ikarus {
     }
 
     /**
-     * @brief Calculates the matrix stiffness for the given FERequirementType.
+     * @brief Calculates the matrix stiffness for the given traction load.
+     *
+     * @tparam ScalarType The scalar type for the stiffness matrix.
      *
      * @param par The FERequirementType object.
      * @param K Matrix to store the calculated stiffness.

--- a/ikarus/finiteelements/mechanics/loads/traction.hh
+++ b/ikarus/finiteelements/mechanics/loads/traction.hh
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <dune/fufem/boundarypatch.hh>
+
+#include <ikarus/finiteelements/ferequirements.hh>
+#include <ikarus/utils/defaultfunctions.hh>
+
+namespace Ikarus {
+
+  /**
+   * @brief Traction class represents distributed traction load that can be applied.
+   *
+   * @ingroup mechanics
+   *
+   * @tparam DisplacementBasedElement The type of the displacement-based finite element.
+   * @tparam Traits Type of traits for handling finite elements.
+   */
+  template <typename DisplacementBasedElement, typename Traits>
+  class Traction {
+  public:
+    using FERequirementType       = typename Traits::FERequirementType;
+    using LocalView               = typename Traits::LocalView;
+    using GridView                = typename Traits::GridView;
+    static constexpr int myDim    = Traits::mydim;
+    static constexpr int worldDim = Traits::worlddim;
+
+    /**
+     * @brief Constructor for the Loads class.
+     *
+     * @param p_dispFE Displacement-based finite element.
+     * @param p_neumannBoundary Neumann boundary patch.
+     * @param p_neumannBoundaryLoad Neumann boundary load function.
+     */
+    template <typename NeumannBoundaryLoad>
+    explicit Traction(const DisplacementBasedElement& p_dispFE, const BoundaryPatch<GridView>* p_neumannBoundary,
+                      NeumannBoundaryLoad p_neumannBoundaryLoad)
+        : dispFE{std::make_shared<DisplacementBasedElement>(p_dispFE)}, neumannBoundary{p_neumannBoundary} {
+      if constexpr (!std::is_same_v<NeumannBoundaryLoad, utils::LoadDefault>)
+        neumannBoundaryLoad = p_neumannBoundaryLoad;
+
+      assert(((not p_neumannBoundary and not neumannBoundaryLoad) or (p_neumannBoundary and neumannBoundaryLoad))
+             && "If you pass a Neumann boundary you should also pass the function for the Neumann load!");
+    }
+
+    /**
+     * @brief Calculates the scalar energy for the given FERequirementType.
+     *
+     * @param par The FERequirementType object.
+     * @return The scalar energy.
+     */
+    template <typename ScalarType>
+    auto calculateScalar(const FERequirementType& par,
+                         const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const -> ScalarType {
+      const auto uFunction = dispFE->displacementFunction(par, dx);
+      ScalarType energy    = 0.0;
+      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
+      auto element         = dispFE->localView().element();
+      if (not neumannBoundary and not neumannBoundaryLoad) return energy;
+
+      for (auto&& intersection : intersections(neumannBoundary->gridView(), element)) {
+        if (not neumannBoundary->contains(intersection)) continue;
+
+        const auto& quadLine = Dune::QuadratureRules<double, myDim - 1>::rule(intersection.type(), dispFE->order());
+
+        for (const auto& curQuad : quadLine) {
+          // Local position of the quadrature point
+          const Dune::FieldVector<double, myDim>& quadPos = intersection.geometryInInside().global(curQuad.position());
+
+          const double integrationElement = intersection.geometry().integrationElement(curQuad.position());
+
+          // The value of the local function
+          const auto uVal = uFunction.evaluate(quadPos);
+
+          // Value of the Neumann data at the current position
+          auto neumannValue = neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
+
+          energy -= neumannValue.dot(uVal) * curQuad.weight() * integrationElement;
+        }
+      }
+      return energy;
+    }
+
+    /**
+     * @brief Applies the distributed traction loads on the element boundary.
+     *
+     * @tparam ScalarType The scalar type for the force vector.
+     * @param par The FERequirementType object.
+     * @param force The force vector to be updated.
+     * @param dx Optional displacement vector.
+     */
+    template <typename ScalarType>
+    void calculateVector(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
+                         const std::optional<const Eigen::VectorX<ScalarType>> dx = std::nullopt) const {
+      using namespace Dune::DerivativeDirections;
+      using namespace Dune;
+      const auto uFunction = dispFE->displacementFunction(par, dx);
+      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
+      auto element         = dispFE->localView().element();
+      if (not neumannBoundary and not neumannBoundaryLoad) return;
+
+      for (auto&& intersection : intersections(neumannBoundary->gridView(), element)) {
+        if (not neumannBoundary->contains(intersection)) continue;
+
+        /// Integration rule along the boundary
+        const auto& quadLine = Dune::QuadratureRules<double, myDim - 1>::rule(intersection.type(), dispFE->order());
+
+        for (const auto& curQuad : quadLine) {
+          const Dune::FieldVector<double, myDim>& quadPos = intersection.geometryInInside().global(curQuad.position());
+          const double intElement = intersection.geometry().integrationElement(curQuad.position());
+
+          /// The value of the local function wrt the i-th coeff
+          for (size_t i = 0; i < dispFE->numberOfNodes(); ++i) {
+            const auto udCi = uFunction.evaluateDerivative(quadPos, wrt(coeff(i)));
+
+            /// Value of the Neumann data at the current position
+            auto neumannValue = neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);
+            force.template segment<worldDim>(worldDim * i) -= udCi * neumannValue * curQuad.weight() * intElement;
+          }
+        }
+      }
+    }
+
+    /**
+     * @brief Calculates the matrix stiffness for the given FERequirementType.
+     *
+     * @param par The FERequirementType object.
+     * @param K Matrix to store the calculated stiffness.
+     */
+    template <typename ScalarType>
+    void calculateMatrix(const FERequirementType& par, typename Traits::template MatrixType<> K,
+                         const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {}
+
+  private:
+    const std::shared_ptr<DisplacementBasedElement> dispFE;
+    std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
+        neumannBoundaryLoad;
+    const BoundaryPatch<GridView>* neumannBoundary;
+  };
+}  // namespace Ikarus

--- a/ikarus/finiteelements/mechanics/loads/volume.hh
+++ b/ikarus/finiteelements/mechanics/loads/volume.hh
@@ -78,8 +78,8 @@ namespace Ikarus {
 
       for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
         const auto uVal                      = uFunction.evaluate(gpIndex);
-        Eigen::Vector<double, worldDim> fext = volumeLoad(geo->global(gp.position()), lambda);
-        energy -= uVal.dot(fext) * geo->integrationElement(gp.position()) * gp.weight();
+        Eigen::Vector<double, worldDim> fext = volumeLoad(geo.global(gp.position()), lambda);
+        energy -= uVal.dot(fext) * geo.integrationElement(gp.position()) * gp.weight();
       }
       return energy;
     }
@@ -95,8 +95,8 @@ namespace Ikarus {
       const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
 
       for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
-        const Eigen::Vector<double, worldDim> fext = volumeLoad(geo->global(gp.position()), lambda);
-        const double intElement                    = geo->integrationElement(gp.position()) * gp.weight();
+        const Eigen::Vector<double, worldDim> fext = volumeLoad(geo.global(gp.position()), lambda);
+        const double intElement                    = geo.integrationElement(gp.position()) * gp.weight();
         for (size_t i = 0; i < dbElement().numberOfNodes(); ++i) {
           const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
           force.template segment<worldDim>(worldDim * i) -= udCi * fext * intElement;

--- a/ikarus/finiteelements/mechanics/loads/volume.hh
+++ b/ikarus/finiteelements/mechanics/loads/volume.hh
@@ -26,6 +26,8 @@ namespace Ikarus {
     /**
      * @brief Constructor for the Loads class.
      *
+     * @tparam VolumeLoad The type for the volume load function.
+     *
      * @param p_volumeLoad Volume load function.
      */
     template <typename VolumeLoad>
@@ -43,7 +45,9 @@ namespace Ikarus {
     }
 
     /**
-     * @brief Calculates the scalar energy for the given FERequirementType.
+     * @brief Calculates the scalar energy for the given volume load.
+     *
+     * @tparam ScalarType The scalar type for the energy.
      *
      * @param par The FERequirementType object.
      * @param dx Optional displacement vector.
@@ -67,9 +71,10 @@ namespace Ikarus {
     }
 
     /**
-     * @brief Applies the distributed volume loads on the element domain.
+     * @brief Calculates the force vector for the given volume load.
      *
      * @tparam ScalarType The scalar type for the force vector.
+     *
      * @param par The FERequirementType object.
      * @param force The force vector to be updated.
      * @param dx Optional displacement vector.
@@ -95,7 +100,9 @@ namespace Ikarus {
     }
 
     /**
-     * @brief Calculates the matrix stiffness for the given FERequirementType.
+     * @brief Calculates the matrix stiffness for the given volume load.
+     *
+     * @tparam ScalarType The scalar type for the stiffness matrix.
      *
      * @param par The FERequirementType object.
      * @param K Matrix to store the calculated stiffness.

--- a/ikarus/finiteelements/mechanics/loads/volume.hh
+++ b/ikarus/finiteelements/mechanics/loads/volume.hh
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <ikarus/finiteelements/ferequirements.hh>
+#include <ikarus/utils/defaultfunctions.hh>
+
+namespace Ikarus {
+
+  /**
+   * @brief Volume class represents distributed volume load that can be applied.
+   *
+   * @ingroup mechanics
+   *
+   * @tparam DisplacementBasedElement The type of the displacement-based finite element.
+   * @tparam Traits Type of traits for handling finite elements.
+   */
+  template <typename DisplacementBasedElement, typename Traits>
+  class Volume {
+  public:
+    using FERequirementType       = typename Traits::FERequirementType;
+    using LocalView               = typename Traits::LocalView;
+    static constexpr int worldDim = Traits::worlddim;
+
+    /**
+     * @brief Constructor for the Loads class.
+     *
+     * @param p_dispFE Displacement-based finite element.
+     * @param p_volumeLoad Volume load function.
+     */
+    template <typename VolumeLoad>
+    explicit Volume(const DisplacementBasedElement& p_dispFE, VolumeLoad p_volumeLoad = {})
+        : dispFE{std::make_shared<DisplacementBasedElement>(p_dispFE)} {
+      if constexpr (!std::is_same_v<VolumeLoad, utils::LoadDefault>) volumeLoad = p_volumeLoad;
+    }
+
+    /**
+     * @brief Calculates the scalar energy for the given FERequirementType.
+     *
+     * @param par The FERequirementType object.
+     * @return The scalar energy.
+     */
+    template <typename ScalarType>
+    auto calculateScalar(const FERequirementType& par,
+                         const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const -> ScalarType {
+      const auto uFunction = dispFE->displacementFunction(par, dx);
+      const auto geo       = dispFE->geometry();
+      ScalarType energy    = 0.0;
+      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
+      if (not(volumeLoad)) return energy;
+
+      for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
+        const auto uVal                      = uFunction.evaluate(gpIndex);
+        Eigen::Vector<double, worldDim> fext = volumeLoad(geo->global(gp.position()), lambda);
+        energy -= uVal.dot(fext) * geo->integrationElement(gp.position()) * gp.weight();
+      }
+      return energy;
+    }
+
+    /**
+     * @brief Applies the distributed volume loads on the element domain.
+     *
+     * @tparam ScalarType The scalar type for the force vector.
+     * @param par The FERequirementType object.
+     * @param force The force vector to be updated.
+     * @param dx Optional displacement vector.
+     */
+    template <typename ScalarType>
+    void calculateVector(const FERequirementType& par, typename Traits::template VectorType<ScalarType> force,
+                         const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
+      using namespace Dune::DerivativeDirections;
+      using namespace Dune;
+
+      const auto& localView = dispFE->localView();
+      std::cout << "Indices in Volume class\n";
+      for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 4; ++j) {
+          const auto localIndex = localView.tree().child(i).localIndex(j);
+          std::cout << "localIndex\t" << localIndex << std::endl;
+          const auto globalIndex = localView.index(localIndex)[0];
+          std::cout << "globalIndex\t" << globalIndex << std::endl;
+        }
+      std::cout << "localView().size()\t" << localView.size() << std::endl;
+      std::cout << "finiteElement.size()\t" << localView.tree().child(0).finiteElement().size() << std::endl;
+      const auto uFunction = dispFE->displacementFunction(par, dx);
+      const auto geo       = dispFE->geometry();
+      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
+      if (not(volumeLoad)) return;
+
+      for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
+        const Eigen::Vector<double, worldDim> fext = volumeLoad(geo->global(gp.position()), lambda);
+        const double intElement                    = geo->integrationElement(gp.position()) * gp.weight();
+        for (size_t i = 0; i < dispFE->numberOfNodes(); ++i) {
+          const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
+          force.template segment<worldDim>(worldDim * i) -= udCi * fext * intElement;
+        }
+      }
+    }
+
+    /**
+     * @brief Calculates the matrix stiffness for the given FERequirementType.
+     *
+     * @param par The FERequirementType object.
+     * @param K Matrix to store the calculated stiffness.
+     */
+    template <typename ScalarType>
+    void calculateMatrix(const FERequirementType& par, typename Traits::template MatrixType<> K,
+                         const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {}
+
+  private:
+    const std::shared_ptr<DisplacementBasedElement> dispFE;
+    std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
+        volumeLoad;
+  };
+}  // namespace Ikarus

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -190,7 +190,7 @@ namespace Ikarus {
       }
     }
 
-    std::shared_ptr<const Geometry> geometry() const { return geo_; }
+    const Geometry& geometry() const { return *geo_; }
     [[nodiscard]] size_t numberOfNodes() const { return numberOfNodes_; }
     [[nodiscard]] int order() const { return order_; }
 

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -54,6 +54,7 @@ namespace Ikarus {
     using LocalView              = typename Traits::LocalView;
     using Geometry               = typename Traits::Geometry;
     using GridView               = typename Traits::GridView;
+    using Element                = typename Traits::Element;
     using BasePowerFE            = PowerBasisFE<FlatBasis>;  // Handles globalIndices function
     using ResultRequirementsType = ResultRequirements<FERequirementType>;
     using Material               = Material_;

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -81,8 +81,8 @@ namespace Ikarus {
                      VolumeLoad p_volumeLoad = {}, const BoundaryPatch<GridView>* p_neumannBoundary = nullptr,
                      NeumannBoundaryLoad p_neumannBoundaryLoad = {})
         : BasePowerFE(globalBasis.flat(), element),
-          VolumeType(*this, p_volumeLoad),
-          TractionType(*this, p_neumannBoundary, p_neumannBoundaryLoad),
+          VolumeType(p_volumeLoad),
+          TractionType(p_neumannBoundary, p_neumannBoundaryLoad),
           mat{p_mat} {
       this->localView().bind(element);
       auto& first_child = this->localView().tree().child(0);

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -281,10 +281,10 @@ namespace Ikarus {
       const auto eps       = strainFunction(par, dx);
       const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
       ScalarType energy    = 0.0;
-        const auto disp           = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
-        Eigen::VectorX<ScalarType> force;
-        force.setZero(numberOfNodes * worldDim);
-        Loads loads(*this);
+      const auto disp      = Dune::viewAsFlatEigenVector(uFunction.coefficientsRef());
+      Eigen::VectorX<ScalarType> force;
+      force.setZero(numberOfNodes * worldDim);
+      Loads loads(*this);
 
       for (const auto& [gpIndex, gp] : eps.viewOverIntegrationPoints()) {
         const auto EVoigt         = (eps.evaluate(gpIndex, on(gridElement))).eval();

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -309,8 +309,7 @@ namespace Ikarus {
                              const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
-      const auto eps = getStrainFunction(par, dx);
-      const auto geo = this->localView().element().geometry();
+      const auto eps = strainFunction(par, dx);
       Loads loads(*this);
 
       // Internal forces

--- a/ikarus/finiteelements/physicshelper.hh
+++ b/ikarus/finiteelements/physicshelper.hh
@@ -11,6 +11,8 @@
 #include <dune/common/float_cmp.hh>
 
 #include <Eigen/Core>
+
+#include <ikarus/finiteelements/ferequirements.hh>
 namespace Ikarus {
 
   /**
@@ -64,8 +66,14 @@ namespace Ikarus {
    */
   template <typename Basis_, typename FERequirements_, bool useRef = false>
   struct TraitsFromFE {
-    using Basis             = Basis_;
+    /** \brief Convenience typedef alias for basis type */
+    using Basis = Basis_;
+
+    /** \brief Convenience typedef alias for FE requirements type */
     using FERequirementType = FERequirements_;
+
+    /** \brief Type of the result requirements */
+    using ResultRequirementsType = ResultRequirements<FERequirementType>;
 
     /** \brief Type of the flat basis */
     using FlatBasis = typename Basis::FlatBasis;

--- a/ikarus/finiteelements/physicshelper.hh
+++ b/ikarus/finiteelements/physicshelper.hh
@@ -76,20 +76,20 @@ namespace Ikarus {
     /** \brief Type of the grid view */
     using GridView = typename FlatBasis::GridView;
 
-    /** \brief Type of the grid entity */
-    using GridEntity = typename LocalView::Element;
+    /** \brief Type of the grid element */
+    using Element = typename LocalView::Element;
 
     /** \brief Type of the element geometry */
-    using Geometry = typename GridEntity::Geometry;
+    using Geometry = typename Element::Geometry;
 
     /** \brief Dimension of the world space */
-    static constexpr int worlddim = GridEntity::Geometry::coorddimension;
+    static constexpr int worlddim = Element::Geometry::coorddimension;
 
     /** \brief Dimension of the geometry */
-    static constexpr int mydim = GridEntity::mydimension;
+    static constexpr int mydim = Element::mydimension;
 
     /** \brief Dimension of the grid */
-    static constexpr int dimension = GridEntity::dimension;
+    static constexpr int dimension = Element::dimension;
 
     /** \brief Type of the internal forces */
     template <typename ScalarType = double>

--- a/ikarus/finiteelements/physicshelper.hh
+++ b/ikarus/finiteelements/physicshelper.hh
@@ -66,10 +66,10 @@ namespace Ikarus {
    */
   template <typename Basis_, typename FERequirements_, bool useRef = false>
   struct TraitsFromFE {
-    /** \brief Convenience typedef alias for basis type */
+    /** \brief Type of the basis of the finite element */
     using Basis = Basis_;
 
-    /** \brief Convenience typedef alias for FE requirements type */
+    /** \brief Type of the requirements for the finite element */
     using FERequirementType = FERequirements_;
 
     /** \brief Type of the result requirements */

--- a/ikarus/finiteelements/physicshelper.hh
+++ b/ikarus/finiteelements/physicshelper.hh
@@ -56,14 +56,32 @@ namespace Ikarus {
   }
 
   /**
-   * \brief Traits for handling local views.
+   * \brief Traits for handling finite elements.
    *
-   * \tparam LocalView Type of the local view.
+   * \tparam Basis_ The basis type for the finite element.
+   * \tparam FERequirements_ The requirements for the finite element.
    * \tparam useRef Boolean indicating whether to use Eigen::Ref for VectorType and MatrixType.
    */
-  template <typename LocalView, bool useRef = false>
-  struct TraitsFromLocalView {
+  template <typename Basis_, typename FERequirements_, bool useRef = false>
+  struct TraitsFromFE {
+    using Basis             = Basis_;
+    using FERequirementType = FERequirements_;
+
+    /** \brief Type of the flat basis */
+    using FlatBasis = typename Basis::FlatBasis;
+
+    /** \brief Type of the local view */
+    using LocalView = typename FlatBasis::LocalView;
+
+    /** \brief Type of the grid view */
+    using GridView = typename FlatBasis::GridView;
+
+    /** \brief Type of the grid entity */
     using GridEntity = typename LocalView::Element;
+
+    /** \brief Type of the element geometry */
+    using Geometry = typename GridEntity::Geometry;
+
     /** \brief Dimension of the world space */
     static constexpr int worlddim = GridEntity::Geometry::coorddimension;
 


### PR DESCRIPTION
This pull request is mainly focused on refactoring based on #159 and #170.
The load functions are moved to a separate class and use generally among different finite elements. 
It can be further probably generalized such that a user can define something like 
```cpp
LoadFunctions lf({.volumeLoad=volumeLoad, .neumannLoad=neumannLoad, .neumannBoundary=neumannBoundary, .someOtherLoad = LoadDefault})
``` 
and pass it along with the constructor of a finite element, but modifying according to this will modify the constructor of all finite elements and hence its necessity can be discussed and implemented in a separate PR perhaps.

The documentation will be updated along with #124.

!!! UPDATE
As per the PR review, `getDisplacementFunction` is refactored separately in #223 