### PR TITLE
Added a wrapper to fix Dirichlet BCs for Lagrange Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ via `pip install pyikarus` ([#152](https://github.com/ikarus-project/ikarus/pull
 - Added getRawMatrix/getRawVector functionality to the assemblers ([#179](https://github.com/ikarus-project/ikarus/pull/179))
 - Add Clang 16 support ([#186](https://github.com/ikarus-project/ikarus/pull/176))
 - Added a default adaptive step sizing possibility and refactored loggers ([#193](https://github.com/ikarus-project/ikarus/pull/193))
+- Added a wrapper to fix Dirichlet BCs for Lagrange Nodes ([#222](https://github.com/ikarus-project/ikarus/pull/222))
 
 - Improve material library and Python bindings ([#186](https://github.com/ikarus-project/ikarus/pull/176)), default e.g.
   `StVenantKirchhoff` is

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.18)
 project(Ikarus-Docs)
 
 find_program(
-        MKDOCS_EXECUTABLE
-        NAMES mkdocs
-        DOC "MkDocs documentation generation tool (http://www.mkdocs.org)" REQUIRED
+  MKDOCS_EXECUTABLE
+  NAMES mkdocs
+  DOC "MkDocs documentation generation tool (http://www.mkdocs.org)" REQUIRED
 )
 
 add_subdirectory(website/doxygen)
@@ -12,16 +12,16 @@ add_subdirectory(website/doxygen)
 add_custom_target(
   site
   COMMAND xvfb-run -a mkdocs build --config-file mkdocs.insiders.yml
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
 add_dependencies(site doxygen_ikarus)
 
 add_custom_target(
-        localSite
-        COMMAND ${MKDOCS_EXECUTABLE} serve
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-        DEPENDS mkdocs-macros.py mkdocs.yml
+  localSite
+  COMMAND ${MKDOCS_EXECUTABLE} serve
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  DEPENDS mkdocs-macros.py mkdocs.yml
 )
 
 add_dependencies(localSite doxygen_ikarus)

--- a/docs/website/01_framework/dirichletBCs.md
+++ b/docs/website/01_framework/dirichletBCs.md
@@ -38,9 +38,9 @@ auto size() const ; // (8)!
 3. A more general version of `fixBoundaryDOFs`. Here, a functor is to be provided that accepts a basis and the corresponding boolean
 4. A function that helps to fix the $i$-th degree of freedom
    vector considering the Dirichlet degrees of freedom.
-4. Returns the underlying basis.
-5. Indicates whether the degree of freedom `i` is fixed.
-6. Returns the number of fixed degrees of freedom.
-7. Returns the number of all dirichlet degrees of freedom.
+5. Returns the underlying basis.
+6. Indicates whether the degree of freedom `i` is fixed.
+7. Returns the number of fixed degrees of freedom.
+8. Returns the number of all dirichlet degrees of freedom.
 
 \bibliography

--- a/docs/website/01_framework/dirichletBCs.md
+++ b/docs/website/01_framework/dirichletBCs.md
@@ -24,17 +24,19 @@ The interface of `#!cpp Ikarus::DirichletValues` is represented by the following
 Ikarus::DirichletValues dirichletValues2(basis); // (1)!
 void fixBoundaryDOFs(f); // (2)!
 void fixDOFs(f); // (3)!
-const auto& basis() const; // (4)!
-bool isConstrained(std::size_t i) const; // (5)!
-auto fixedDOFsize() const; // (6)!
-auto size() const ; // (7)!
+void fixIthDOF(i); // (4)!
+const auto& basis() const; // (5)!
+bool isConstrained(std::size_t i) const; // (6)!
+auto fixedDOFsize() const; // (7)!
+auto size() const ; // (8)!
 ```
 
 1. Create class by inserting a global basis, [@sander2020dune] Chapter 10.
 2. Accepts a functor to fix boundary degrees of freedom. `f` is  a functor that will be called with the boolean vector of fixed boundary.
- degrees of freedom and the usual arguments of `Dune::Functions::forEachBoundaryDOF`,  as defined on page 388 of the Dune
+ degrees of freedom and the usual arguments of `Dune::Functions::forEachBoundaryDOF`, as defined on page 388 of the Dune
    [@sander2020dune] book.
 3. A more general version of `fixBoundaryDOFs`. Here, a functor is to be provided that accepts a basis and the corresponding boolean
+4. A function that helps to fix the $i$-th degree of freedom
    vector considering the Dirichlet degrees of freedom.
 4. Returns the underlying basis.
 5. Indicates whether the degree of freedom `i` is fixed.

--- a/ikarus/linearalgebra/dirichletvalues.hh
+++ b/ikarus/linearalgebra/dirichletvalues.hh
@@ -77,7 +77,7 @@ namespace Ikarus {
      *
      * \param i An index indicating the DOF number to be fixed
      */
-    void fixIthDOF(std::size_t i) { dirichletFlags[i] = true; }
+    void fixIthDOF(typename Basis::MultiIndex i) { dirichletFlagsBackend[i] = true; }
 
     /* \brief Returns the local basis object */
     const auto& basis() const { return basis_; }

--- a/ikarus/linearalgebra/dirichletvalues.hh
+++ b/ikarus/linearalgebra/dirichletvalues.hh
@@ -72,6 +72,13 @@ namespace Ikarus {
       f(basis_, dirichletFlagsBackend);
     }
 
+    /**
+     * \brief Function to fix (set boolean values to true or false) of degrees of freedom
+     *
+     * \param i An index indicating the DOF number to be fixed
+     */
+    void fixIthDOF(std::size_t i) { dirichletFlags[i] = true; }
+
     /* \brief Returns the local basis object */
     const auto& basis() const { return basis_; }
 

--- a/ikarus/utils/linearalgebrahelper.hh
+++ b/ikarus/utils/linearalgebrahelper.hh
@@ -366,14 +366,15 @@ namespace Ikarus {
   /* A function to obtain the global positions of the nodes of an element with Lagrangian basis
    * (Refer - Dune Book Section 8.3.1, Page 314)
    */
-  template <typename ElementType, typename LocalFE, int size>
-  void obtainLagrangeNodePositions(const ElementType& ele, const LocalFE& localFE,
+  template <int order, int size, typename LocalView>
+  void obtainLagrangeNodePositions(const LocalView& localView,
                                    std::vector<Dune::FieldVector<double, size>>& lagrangeNodeCoords) {
     static_assert(
-        std::is_same_v<std::remove_cvref_t<decltype(localFE.localView().tree().child(0))>,
-                       Dune::Functions::LagrangeNode<
-                           std::remove_cvref_t<decltype(localFE.localView().globalBasis().gridView())>, size, double>>,
+        std::is_same_v<typename std::remove_cvref_t<decltype(localView.tree().child(0))>,
+                       Dune::Functions::LagrangeNode<std::remove_cvref_t<decltype(localView.globalBasis().gridView())>,
+                                                     order, double>>,
         "This function is only supported for Lagrange basis");
+    const auto& localFE = localView.tree().child(0).finiteElement();
     lagrangeNodeCoords.resize(localFE.size());
     std::vector<double> out;
     for (int i = 0; i < size; i++) {
@@ -383,7 +384,7 @@ namespace Ikarus {
         lagrangeNodeCoords[j][i] = out[j];
     }
     for (auto& nCoord : lagrangeNodeCoords)
-      nCoord = ele.geometry().global(nCoord);
+      nCoord = localView.element().geometry().global(nCoord);
   }
 
 }  // namespace Ikarus

--- a/ikarus/utils/linearalgebrahelper.hh
+++ b/ikarus/utils/linearalgebrahelper.hh
@@ -9,7 +9,7 @@
 #include <random>
 
 #include <dune/common/tuplevector.hh>
-#include <dune/functions/functionspacebases/lagrangedgbasis.hh>
+#include <dune/functions/functionspacebases/lagrangebasis.hh>
 #include <dune/istl/bvector.hh>
 #include <dune/istl/multitypeblockvector.hh>
 

--- a/ikarus/utils/linearalgebrahelper.hh
+++ b/ikarus/utils/linearalgebrahelper.hh
@@ -363,8 +363,16 @@ namespace Ikarus {
   template <int dim>
   constexpr auto voigtNotationContainer = std::get<dim - 1>(Impl::voigtIndices);
 
-  /* A function to obtain the global positions of the nodes of an element with Lagrangian basis
-   * (Refer - Dune Book Section 8.3.1, Page 314)
+  /**
+   * \brief A function to obtain the global positions of the nodes of an element with Lagrangian basis, see Dune book
+   * page 314
+   *
+   * \tparam order Polynomial order of the Lagrangian basis
+   * \tparam size Size of the nodal coordinate vector
+   * \tparam LocalView Type of the local view
+   *
+   * \param localView Local View bounded to an element
+   * \param lagrangeNodeCoords A vector of nodal coordinates to be updated
    */
   template <int order, int size, typename LocalView>
   void obtainLagrangeNodePositions(const LocalView& localView,

--- a/ikarus/utils/linearalgebrahelper.hh
+++ b/ikarus/utils/linearalgebrahelper.hh
@@ -371,7 +371,7 @@ namespace Ikarus {
    * \tparam size Size of the nodal coordinate vector
    * \tparam LocalView Type of the local view
    *
-   * \param localView Local View bounded to an element
+   * \param localView Local view bounded to an element
    * \param lagrangeNodeCoords A vector of nodal coordinates to be updated
    */
   template <int order, int size, typename LocalView>

--- a/tests/src/testassembler.cpp
+++ b/tests/src/testassembler.cpp
@@ -156,9 +156,9 @@ auto SimpleAssemblersTest(const PreBasis& preBasis) {
 
     constexpr double tol = 1e-8;
     auto localView       = basis.flat().localView();
-    for (auto &ele : elements(gridView)) {
+    for (auto& ele : elements(gridView)) {
       localView.bind(ele);
-      const auto &fe = localView.tree().child(0).finiteElement();
+      const auto& fe = localView.tree().child(0).finiteElement();
       std::vector<Dune::FieldVector<double, 2>> nodalPos;
       Ikarus::obtainLagrangeNodePositions<order>(localView, nodalPos);
       for (int i = 0; i < fe.size(); i++)

--- a/tests/src/testassembler.cpp
+++ b/tests/src/testassembler.cpp
@@ -20,7 +20,6 @@ using Dune::TestSuite;
 #include <ikarus/finiteelements/mechanics/nonlinearelastic.hh>
 #include <ikarus/utils/basis.hh>
 #include <ikarus/utils/init.hh>
-#include <ikarus/utils/linearalgebrahelper.hh>
 
 template <typename TestSuiteType, typename SparseType, typename DenseType, typename DOFSize>
 void checkAssembledQuantities(TestSuiteType& t, SparseType& sType, DenseType& dType, DOFSize dofSize) {
@@ -32,14 +31,12 @@ void checkAssembledQuantities(TestSuiteType& t, SparseType& sType, DenseType& dT
         << "DOFsCheck via columns: " << sType.cols() << "cols and " << dofSize << " DOFs";
 }
 
-template <int order, typename PreBasis>
+template <typename PreBasis>
 auto SimpleAssemblersTest(const PreBasis& preBasis) {
   TestSuite t("SimpleAssemblersTest");
   using Grid = Dune::YaspGrid<2>;
 
-  const double Lx                         = 4.0;
-  const double Ly                         = 2.0;
-  Dune::FieldVector<double, 2> bbox       = {Lx, Ly};
+  Dune::FieldVector<double, 2> bbox       = {4, 2};
   std::array<int, 2> elementsPerDirection = {2, 1};
   auto grid                               = std::make_shared<Grid>(bbox, elementsPerDirection);
 
@@ -66,7 +63,6 @@ auto SimpleAssemblersTest(const PreBasis& preBasis) {
 
     auto basisP = std::make_shared<const decltype(basis)>(basis);
     Ikarus::DirichletValues dirichletValues(basisP->flat());
-    Ikarus::DirichletValues dirichletValues2(basisP->flat());
     dirichletValues.fixDOFs([](auto& basis_, auto& dirichletFlags) {
       Dune::Functions::forEachBoundaryDOF(basis_, [&](auto&& indexGlobal) { dirichletFlags[indexGlobal] = true; });
     });
@@ -154,26 +150,6 @@ auto SimpleAssemblersTest(const PreBasis& preBasis) {
       }
     }
 
-    constexpr double tol = 1e-8;
-    auto localView       = basis.flat().localView();
-    for (auto& ele : elements(gridView)) {
-      localView.bind(ele);
-      const auto& fe = localView.tree().child(0).finiteElement();
-      std::vector<Dune::FieldVector<double, 2>> nodalPos;
-      Ikarus::obtainLagrangeNodePositions<order>(localView, nodalPos);
-      for (int i = 0; i < fe.size(); i++)
-        if ((std::abs(nodalPos[i][0]) < tol) or (std::abs(nodalPos[i][0] - Lx) < tol)
-            or (std::abs(nodalPos[i][1]) < tol) or (std::abs(nodalPos[i][1] - Ly) < tol))
-          for (auto fixedDirection = 0; fixedDirection < 2; ++fixedDirection) {
-            auto fixIndex = localView.index(localView.tree().child(fixedDirection).localIndex(i));
-            dirichletValues2.fixIthDOF(fixIndex);
-          }
-    }
-
-    t.check(fixedDOFs == dirichletValues2.fixedDOFsize())
-        << "Fixed DOF size is not the same for dirichletValues (" << fixedDOFs << ") and dirichletValues2 ("
-        << dirichletValues2.fixedDOFsize() << ")";
-
     grid->globalRefine(1);
   }
   return t;
@@ -187,7 +163,7 @@ int main(int argc, char** argv) {
   auto firstOrderLagrangePrePower2Basis  = power<2>(lagrange<1>(), FlatInterleaved());
   auto secondOrderLagrangePrePower2Basis = power<2>(lagrange<2>(), FlatInterleaved());
 
-  t.subTest(SimpleAssemblersTest<1>(firstOrderLagrangePrePower2Basis));
-  t.subTest(SimpleAssemblersTest<2>(secondOrderLagrangePrePower2Basis));
+  t.subTest(SimpleAssemblersTest(firstOrderLagrangePrePower2Basis));
+  t.subTest(SimpleAssemblersTest(secondOrderLagrangePrePower2Basis));
   return t.exit();
 }


### PR DESCRIPTION
This PR basically adds a function called `obtainLagrangeNodePositions` that helps to obtain the global positions of the Lagrangian nodes. This is adapted from the Dune book (Section 8.3.1). This can then be combined with the member function `fixIthDOF` of the class `DirichletValues` to fix particular DOFs. This mainly helps if in case the user uses higher order elements with nodes living on the middle of the edges of elements, for example, to be fixed.