### PR TITLE
Refactor getDisplacementFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ via `pip install pyikarus` ([#152](https://github.com/ikarus-project/ikarus/pull
 - Add Clang 16 support ([#186](https://github.com/ikarus-project/ikarus/pull/176))
 - Added a default adaptive step sizing possibility and refactored loggers ([#193](https://github.com/ikarus-project/ikarus/pull/193))
 - Added a wrapper to fix Dirichlet BCs for Lagrange Nodes ([#222](https://github.com/ikarus-project/ikarus/pull/222))
+- Refactored `getDisplacementFunction` in finite elements ([#223](https://github.com/ikarus-project/ikarus/pull/223))
 
 - Improve material library and Python bindings ([#186](https://github.com/ikarus-project/ikarus/pull/176)), default e.g.
   `StVenantKirchhoff` is

--- a/docs/website/01_framework/finiteElements.md
+++ b/docs/website/01_framework/finiteElements.md
@@ -110,7 +110,7 @@ calculateScalarImpl(const FERequirementType& par, const Eigen::VectorX<ScalarTyp
 calculateVectorImpl(const FERequirementType& par, const Eigen::VectorX<ScalarType>& dx, Eigen::VectorX<ScalarType>& force)
 ```
 
-Inside `getStrainFunction(const FERequirementType& par, const Eigen::VectorX<ScalarType>& dx)` is used to get the desired strain measure.
+Inside `strainFunction(const FERequirementType& par, const Eigen::VectorX<ScalarType>& dx)` is used to get the desired strain measure.
 It can be used to toggle between the geometrically linear and non-linear cases.
 `LinearStrains` are used for the geometrically linear case, while `GreenLagrangianStrains` are used for the non-linear case.
 These strain measures are defined as expressions in `dune-localfefunctions`. Refer to [Expressions](localFunctions.md#expressions) for more details.

--- a/ikarus/finiteelements/CMakeLists.txt
+++ b/ikarus/finiteelements/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # install headers
-install(FILES ferequirements.hh fetraits.hh physicshelper.hh
+install(FILES ferequirements.hh fetraits.hh fehelper.hh physicshelper.hh
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements
 )
 

--- a/ikarus/finiteelements/fehelper.hh
+++ b/ikarus/finiteelements/fehelper.hh
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <dune/localfefunctions/manifolds/realTuple.hh>
+
+#include <ikarus/finiteelements/ferequirements.hh>
+#include <ikarus/finiteelements/physicshelper.hh>
+
+namespace Ikarus::FEHelper {
+  /**
+   * @brief Gets the local solution Dune block vector
+   *
+   * @tparam FERequirementType Type of the FE requirements.
+   * @tparam LocalView Type of the local view.
+   * @tparam ScalarType Scalar type for the local solution vector.
+   *
+   * @param x The global solution vector.
+   * @param localView Local view of the element.
+   * @param dx Optional global solution vector.
+   *
+   * @return A Dune block vector representing the solution quantities at each node.
+   * */
+  template <typename FERequirementType, typename LocalView, typename ScalarType>
+  auto localSolutionBlockVector(const typename FERequirementType::SolutionVectorTypeRaw& x, const LocalView& localView,
+                                const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) {
+    using Traits           = TraitsFromLocalView<LocalView>;
+    constexpr int worldDim = Traits::worlddim;
+    const auto& fe         = localView.tree().child(0).finiteElement();
+    Dune::BlockVector<Dune::RealTuple<ScalarType, worldDim>> localX(fe.size());
+    if (dx)
+      for (auto i = 0U; i < localX.size(); ++i)
+        for (auto j = 0U; j < worldDim; ++j)
+          localX[i][j] = dx.value()[i * worldDim + j] + x[localView.index(localView.tree().child(j).localIndex(i))[0]];
+    else
+      for (auto i = 0U; i < localX.size(); ++i)
+        for (auto j = 0U; j < worldDim; ++j)
+          localX[i][j] = x[localView.index(localView.tree().child(j).localIndex(i))[0]];
+    return localX;
+  }
+}  // namespace Ikarus::FEHelper

--- a/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
+++ b/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
@@ -50,6 +50,7 @@ namespace Ikarus {
     static constexpr int myDim    = Traits::mydim;
     static constexpr int worldDim = Traits::worlddim;
     using LocalBasisType          = decltype(std::declval<LocalView>().tree().child(0).finiteElement().localBasis());
+
     static constexpr int membraneStrainSize = 3;
     static constexpr int bendingStrainSize  = 3;
 
@@ -193,6 +194,7 @@ namespace Ikarus {
       DUNE_THROW(Dune::NotImplemented, "No results are implemented");
     }
 
+    std::shared_ptr<const Geometry> geo_;
     Dune::CachedLocalBasis<std::remove_cvref_t<LocalBasisType>> localBasis;
     std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
         volumeLoad;
@@ -205,7 +207,6 @@ namespace Ikarus {
     double thickness_;
     size_t numberOfNodes{0};
     int order{};
-    std::shared_ptr<const Geometry> geo_;
 
   protected:
     /**

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -219,8 +219,9 @@ namespace Ikarus {
     }
 
     Dune::CachedLocalBasis<std::remove_cvref_t<LocalBasisType>> localBasis;
-    std::function<Eigen::Vector<double, worldDim>(const Eigen::Vector<double, worldDim>&, const double&)> volumeLoad;
-    std::function<Eigen::Vector<double, worldDim>(const Eigen::Vector<double, worldDim>&, const double&)>
+    std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
+        volumeLoad;
+    std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
         neumannBoundaryLoad;
     const BoundaryPatch<GridView>* neumannBoundary;
     double emod_;
@@ -252,7 +253,7 @@ namespace Ikarus {
       if (volumeLoad) {
         for (const auto& [gpIndex, gp] : eps.viewOverIntegrationPoints()) {
           const auto uVal                              = uFunction.evaluate(gpIndex);
-          Eigen::Vector<double, Traits::worlddim> fext = volumeLoad(toEigen(geo_->global(gp.position())), lambda);
+          Eigen::Vector<double, Traits::worlddim> fext = volumeLoad(geo_->global(gp.position()), lambda);
           energy -= uVal.dot(fext) * geo_->integrationElement(gp.position()) * gp.weight();
         }
       }
@@ -308,7 +309,7 @@ namespace Ikarus {
       // External forces volume forces over the domain
       if (volumeLoad) {
         for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
-          Eigen::Vector<double, Traits::worlddim> fext = volumeLoad(toEigen(geo_->global(gp.position())), lambda);
+          Eigen::Vector<double, Traits::worlddim> fext = volumeLoad(geo_->global(gp.position()), lambda);
           for (size_t i = 0; i < numberOfNodes; ++i) {
             const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
             force.template segment<myDim>(myDim * i)

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -218,6 +218,7 @@ namespace Ikarus {
         DUNE_THROW(Dune::NotImplemented, "The requested result type is NOT implemented.");
     }
 
+    std::shared_ptr<const Geometry> geo_;
     Dune::CachedLocalBasis<std::remove_cvref_t<LocalBasisType>> localBasis;
     std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
         volumeLoad;
@@ -228,7 +229,6 @@ namespace Ikarus {
     double nu_;
     size_t numberOfNodes{0};
     int order{};
-    std::shared_ptr<const Geometry> geo_;
 
   protected:
     template <typename ScalarType>

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -19,6 +19,7 @@
 #  include <dune/localfefunctions/manifolds/realTuple.hh>
 
 #  include <ikarus/finiteelements/febases/powerbasisfe.hh>
+#  include <ikarus/finiteelements/fehelper.hh>
 #  include <ikarus/finiteelements/ferequirements.hh>
 #  include <ikarus/finiteelements/fetraits.hh>
 #  include <ikarus/finiteelements/mechanics/materials/tags.hh>
@@ -54,7 +55,9 @@ namespace Ikarus {
     using GridView                   = typename FlatBasis::GridView;
     using Traits                     = TraitsFromLocalView<LocalView, useEigenRef>;
     static constexpr int myDim       = Traits::mydim;
+    static constexpr int worldDim    = Traits::worlddim;
     static constexpr auto strainType = StrainTags::greenLagrangian;
+    using LocalBasisType             = decltype(std::declval<LocalView>().tree().child(0).finiteElement().localBasis());
 
     /**
      * @brief Constructor for the NonLinearElastic class.
@@ -76,10 +79,10 @@ namespace Ikarus {
       this->localView().bind(element);
       auto& first_child = this->localView().tree().child(0);
       const auto& fe    = first_child.finiteElement();
+      geo_              = std::make_shared<const Geometry>(this->localView().element().geometry());
       numberOfNodes     = fe.size();
-      dispAtNodes.resize(numberOfNodes);
-      order      = 2 * (this->localView().tree().child(0).finiteElement().localBasis().order());
-      localBasis = Dune::CachedLocalBasis(this->localView().tree().child(0).finiteElement().localBasis());
+      order             = 2 * (fe.localBasis().order());
+      localBasis        = Dune::CachedLocalBasis(fe.localBasis());
       if constexpr (requires { this->localView().element().impl().getQuadratureRule(order); })
         if (this->localView().element().impl().isTrimmed())
           localBasis.bind(this->localView().element().impl().getQuadratureRule(order), Dune::bindDerivatives(0, 1));
@@ -110,22 +113,8 @@ namespace Ikarus {
     auto displacementFunction(const FERequirementType& par,
                               const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
       const auto& d = par.getGlobalSolution(Ikarus::FESolutions::displacement);
-
-      Dune::BlockVector<Dune::RealTuple<ScalarType, Traits::dimension>> disp(dispAtNodes.size());
-      // If optional displacement vector is provided, apply it
-      if (dx)
-        for (auto i = 0U; i < disp.size(); ++i)
-          for (auto k2 = 0U; k2 < myDim; ++k2)
-            disp[i][k2] = dx.value()[i * myDim + k2]
-                          + d[this->localView().index(this->localView().tree().child(k2).localIndex(i))[0]];
-      else
-        for (auto i = 0U; i < disp.size(); ++i)
-          for (auto k2 = 0U; k2 < myDim; ++k2)
-            disp[i][k2] = d[this->localView().index(this->localView().tree().child(k2).localIndex(i))[0]];
-
-      auto geo = std::make_shared<const typename GridView::GridView::template Codim<0>::Entity::Geometry>(
-          this->localView().element().geometry());
-      Dune::StandardLocalFunction uFunction(localBasis, disp, geo);
+      auto disp     = Ikarus::FEHelper::localSolutionBlockVector<FERequirementType>(d, this->localView(), dx);
+      Dune::StandardLocalFunction uFunction(localBasis, disp, geo_);
       return uFunction;
     }
 
@@ -138,9 +127,9 @@ namespace Ikarus {
      * @return The strain function calculated using greenLagrangeStrains.
      */
     template <typename ScalarType = double>
-    auto strainFunction(const FERequirementType& par,
-                        const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
-      return greenLagrangeStrains(displacementFunction(par, dx));
+    inline auto strainFunction(const FERequirementType& par,
+                               const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
+      return Dune::greenLagrangeStrains(displacementFunction(par, dx));
     }
 
     /**
@@ -153,7 +142,7 @@ namespace Ikarus {
      * @return The material tangent calculated using the material's tangentModuli function.
      */
     template <typename ScalarType, int strainDim, bool voigt = true>
-    auto getMaterialTangent(const Eigen::Vector<ScalarType, strainDim>& strain) const {
+    auto materialTangent(const Eigen::Vector<ScalarType, strainDim>& strain) const {
       if constexpr (std::is_same_v<ScalarType, double>)
         return mat.template tangentModuli<strainType, voigt>(strain);
       else {
@@ -230,12 +219,10 @@ namespace Ikarus {
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
       const auto eps = strainFunction(par);
-      const auto geo = this->localView().element().geometry();
-
       for (const auto& [gpIndex, gp] : eps.viewOverIntegrationPoints()) {
-        const double intElement = geo.integrationElement(gp.position()) * gp.weight();
+        const double intElement = geo_->integrationElement(gp.position()) * gp.weight();
         const auto EVoigt       = (eps.evaluate(gpIndex, on(gridElement))).eval();
-        const auto C            = getMaterialTangent(EVoigt);
+        const auto C            = materialTangent(EVoigt);
         const auto stresses     = getStress(EVoigt);
         for (size_t i = 0; i < numberOfNodes; ++i) {
           const auto bopI = eps.evaluateDerivative(gpIndex, wrt(coeff(i)), on(gridElement));
@@ -272,20 +259,15 @@ namespace Ikarus {
         DUNE_THROW(Dune::NotImplemented, "The requested result type is NOT implemented.");
     }
 
-    Dune::CachedLocalBasis<
-        std::remove_cvref_t<decltype(std::declval<LocalView>().tree().child(0).finiteElement().localBasis())>>
-        localBasis;
-    std::function<Eigen::Vector<double, Traits::worlddim>(const Dune::FieldVector<double, Traits::worlddim>&,
-                                                          const double&)>
-        volumeLoad;
-    std::function<Eigen::Vector<double, Traits::worlddim>(const Dune::FieldVector<double, Traits::worlddim>&,
-                                                          const double&)>
+    Dune::CachedLocalBasis<std::remove_cvref_t<LocalBasisType>> localBasis;
+    std::function<Eigen::Vector<double, worldDim>(const Eigen::Vector<double, worldDim>&, const double&)> volumeLoad;
+    std::function<Eigen::Vector<double, worldDim>(const Eigen::Vector<double, worldDim>&, const double&)>
         neumannBoundaryLoad;
     const BoundaryPatch<GridView>* neumannBoundary;
     Material mat;
-    mutable Dune::BlockVector<Dune::RealTuple<double, Traits::dimension>> dispAtNodes;
     size_t numberOfNodes{0};
     int order{};
+    std::shared_ptr<const Geometry> geo_;
 
   protected:
     template <typename ScalarType>
@@ -296,20 +278,19 @@ namespace Ikarus {
       const auto uFunction = displacementFunction(par, dx);
       const auto eps       = strainFunction(par, dx);
       const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
-      const auto geo       = this->localView().element().geometry();
       ScalarType energy    = 0.0;
 
       for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
         const auto EVoigt         = (eps.evaluate(gpIndex, on(gridElement))).eval();
         const auto internalEnergy = getInternalEnergy(EVoigt);
-        energy += internalEnergy * geo.integrationElement(gp.position()) * gp.weight();
+        energy += internalEnergy * geo_->integrationElement(gp.position()) * gp.weight();
       }
 
       if (volumeLoad) {
         for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
           const auto u                                       = uFunction.evaluate(gpIndex);
-          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(geo.global(gp.position()), lambda);
-          energy -= u.dot(fExt) * geo.integrationElement(gp.position()) * gp.weight();
+          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(toEigen(geo_->global(gp.position())), lambda);
+          energy -= u.dot(fExt) * geo_->integrationElement(gp.position()) * gp.weight();
         }
       }
 
@@ -345,13 +326,13 @@ namespace Ikarus {
                              const std::optional<const Eigen::VectorX<ScalarType>>& dx = std::nullopt) const {
       using namespace Dune::DerivativeDirections;
       using namespace Dune;
-      const auto& lambda = par.getParameter(Ikarus::FEParameter::loadfactor);
-      const auto eps     = strainFunction(par, dx);
-      const auto geo     = this->localView().element().geometry();
+      const auto& lambda   = par.getParameter(Ikarus::FEParameter::loadfactor);
+      const auto uFunction = displacementFunction(par, dx);
+      const auto eps       = strainFunction(par, dx);
 
       // Internal forces
       for (const auto& [gpIndex, gp] : eps.viewOverIntegrationPoints()) {
-        const double intElement = geo.integrationElement(gp.position()) * gp.weight();
+        const double intElement = geo_->integrationElement(gp.position()) * gp.weight();
         const auto EVoigt       = (eps.evaluate(gpIndex, on(gridElement))).eval();
         const auto stresses     = getStress(EVoigt);
         for (size_t i = 0; i < numberOfNodes; ++i) {
@@ -362,12 +343,11 @@ namespace Ikarus {
 
       // External forces volume forces over the domain
       if (volumeLoad) {
-        const auto u = displacementFunction(par, dx);
-        for (const auto& [gpIndex, gp] : u.viewOverIntegrationPoints()) {
-          const double intElement                            = geo.integrationElement(gp.position()) * gp.weight();
-          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(geo.global(gp.position()), lambda);
+        for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
+          const double intElement                            = geo_->integrationElement(gp.position()) * gp.weight();
+          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(toEigen(geo_->global(gp.position())), lambda);
           for (size_t i = 0; i < numberOfNodes; ++i) {
-            const auto udCi = u.evaluateDerivative(gpIndex, wrt(coeff(i)));
+            const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
             force.template segment<myDim>(myDim * i) -= udCi * fExt * intElement;
           }
         }
@@ -375,8 +355,6 @@ namespace Ikarus {
 
       // External forces, boundary forces, i.e., at the Neumann boundary
       if (not neumannBoundary and not neumannBoundaryLoad) return;
-
-      const auto u        = displacementFunction(par, dx);
       const auto& element = this->localView().element();
       for (auto&& intersection : intersections(neumannBoundary->gridView(), element)) {
         if (not neumannBoundary->contains(intersection)) continue;
@@ -391,7 +369,7 @@ namespace Ikarus {
 
           // The value of the local function wrt the i-th coefficient
           for (size_t i = 0; i < numberOfNodes; ++i) {
-            const auto udCi = u.evaluateDerivative(quadPos, wrt(coeff(i)));
+            const auto udCi = uFunction.evaluateDerivative(quadPos, wrt(coeff(i)));
 
             // Value of the Neumann data at the current position
             const auto neumannValue = neumannBoundaryLoad(intersection.geometry().global(curQuad.position()), lambda);

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -259,6 +259,7 @@ namespace Ikarus {
         DUNE_THROW(Dune::NotImplemented, "The requested result type is NOT implemented.");
     }
 
+    std::shared_ptr<const Geometry> geo_;
     Dune::CachedLocalBasis<std::remove_cvref_t<LocalBasisType>> localBasis;
     std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
         volumeLoad;
@@ -268,7 +269,6 @@ namespace Ikarus {
     Material mat;
     size_t numberOfNodes{0};
     int order{};
-    std::shared_ptr<const Geometry> geo_;
 
   protected:
     template <typename ScalarType>

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -260,8 +260,9 @@ namespace Ikarus {
     }
 
     Dune::CachedLocalBasis<std::remove_cvref_t<LocalBasisType>> localBasis;
-    std::function<Eigen::Vector<double, worldDim>(const Eigen::Vector<double, worldDim>&, const double&)> volumeLoad;
-    std::function<Eigen::Vector<double, worldDim>(const Eigen::Vector<double, worldDim>&, const double&)>
+    std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
+        volumeLoad;
+    std::function<Eigen::Vector<double, worldDim>(const Dune::FieldVector<double, worldDim>&, const double&)>
         neumannBoundaryLoad;
     const BoundaryPatch<GridView>* neumannBoundary;
     Material mat;
@@ -289,7 +290,7 @@ namespace Ikarus {
       if (volumeLoad) {
         for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
           const auto u                                       = uFunction.evaluate(gpIndex);
-          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(toEigen(geo_->global(gp.position())), lambda);
+          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(geo_->global(gp.position()), lambda);
           energy -= u.dot(fExt) * geo_->integrationElement(gp.position()) * gp.weight();
         }
       }
@@ -345,7 +346,7 @@ namespace Ikarus {
       if (volumeLoad) {
         for (const auto& [gpIndex, gp] : uFunction.viewOverIntegrationPoints()) {
           const double intElement                            = geo_->integrationElement(gp.position()) * gp.weight();
-          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(toEigen(geo_->global(gp.position())), lambda);
+          const Eigen::Vector<double, Traits::worlddim> fExt = volumeLoad(geo_->global(gp.position()), lambda);
           for (size_t i = 0; i < numberOfNodes; ++i) {
             const auto udCi = uFunction.evaluateDerivative(gpIndex, wrt(coeff(i)));
             force.template segment<myDim>(myDim * i) -= udCi * fExt * intElement;

--- a/ikarus/python/finiteelements/registerelement.hh
+++ b/ikarus/python/finiteelements/registerelement.hh
@@ -119,8 +119,8 @@ namespace Ikarus::Python {
         },
         pybind11::arg("FERequirements"), pybind11::arg("elementMatrix").noconvert());
 
-    if constexpr (requires { std::declval<FE>().getMaterialTangent(); })
-      cls.def("getMaterialTangent", [](FE& self) { return self.getMaterialTangent(); });
+    if constexpr (requires { std::declval<FE>().materialTangent(); })
+      cls.def("materialTangent", [](FE& self) { return self.materialTangent(); });
 
     cls.def(
         "resultAt",

--- a/tests/src/testklshell.cpp
+++ b/tests/src/testklshell.cpp
@@ -147,9 +147,9 @@ static auto NonLinearKLShellLoadControlTR() {
 
   const auto maxDisp = std::ranges::max(d);
   std::cout << std::setprecision(16) << maxDisp << std::endl;
-  t.check(Dune::FloatCmp::eq(0.2087574597947082, maxDisp, 1e-6))
-      << std::setprecision(16) << "The maximum displacement is " << maxDisp << "but it should be " << 0.2087574597947082
-      << ". The difference is " << 0.2087574597947082 - maxDisp;
+  t.check(Dune::FloatCmp::eq(0.2087577577946809, maxDisp, 1e-6))
+      << std::setprecision(16) << "The maximum displacement is " << maxDisp << "but it should be " << 0.2087577577946809
+      << ". The difference is " << 0.2087577577946809 - maxDisp;
   return t;
 }
 

--- a/tests/src/testklshell.cpp
+++ b/tests/src/testklshell.cpp
@@ -208,4 +208,5 @@ int main(int argc, char** argv) {
   TestSuite t("Kirchhoff-Love");
   t.subTest(singleElementTest());
   t.subTest(NonLinearKLShellLoadControlTR());
+  return t.exit();
 }


### PR DESCRIPTION
This PR was split from #221. See #221 for some PR review comments.

!!! UPDATE
`std::optional` version in finite elements has to be removed and the `if-else` branch in `localSolutionBlockVector` has to be determined during compile time. This will be addressed in #228 