### PR TITLE
refactor enhancedassumedstrains.hh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgar
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 
+- Add tensorProduct quadrature rule and [0,1] to [-1,1] transformation ([#238](https://github.com/ikarus-project/ikarus/pull/238))
+- Refactor `enhancedassumedstrains.hh` ([#247](https://github.com/ikarus-project/ikarus/pull/247))
+
 ## Release v0.4 (Ganymede)
 
 - Add CODE_OF_CONDUCT.md file
-- Refactored Cmake and directory structure  ([#146](https://github.com/ikarus-project/ikarus/pull/146))
+- Refactored Cmake and directory structure ([#146](https://github.com/ikarus-project/ikarus/pull/146))
 - Added comment section to blog post ([511d83](https://github.com/ikarus-project/ikarus/commit/511d83f9e7c474c9b320db5bc9367114ebe2825d))
 - Updated license information ([#138](https://github.com/ikarus-project/ikarus/pull/138))
 - Added detailed documentation for ikarus-examples ([#140](https://github.com/ikarus-project/ikarus/pull/140))

--- a/ikarus/finiteelements/mechanics/CMakeLists.txt
+++ b/ikarus/finiteelements/mechanics/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
 # SPDX-License-Identifier: LGPL-3.0-or-later
+add_subdirectory(eas)
 add_subdirectory(loads)
 add_subdirectory(materials)
 # install headers
@@ -11,5 +12,6 @@ install(
         kirchhoffloveshell.hh
         membranestrains.hh
         loads.hh
+        easvariants.hh
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/mechanics
 )

--- a/ikarus/finiteelements/mechanics/eas/CMakeLists.txt
+++ b/ikarus/finiteelements/mechanics/eas/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# install headers
+install(FILES eas2d.hh eas3d.hh
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/mechanics/eas
+)

--- a/ikarus/finiteelements/mechanics/eas/eas2d.hh
+++ b/ikarus/finiteelements/mechanics/eas/eas2d.hh
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+/**
+ * @file eas2d.hh
+ * @brief Definition of the types of EAS formulations for 2D elements.
+ * @ingroup  eas
+ */
+
+#pragma once
+
+#include <ikarus/utils/tensorutils.hh>
+
+namespace Ikarus::EAS {
+
+/**
+ * @brief Q1E4 structure for EAS with linear strains and 4 enhanced modes.
+ *
+ * \details The Q1E4 structure represents an implementation of EAS for a
+ * specific case where linear strains are considered, and the method includes
+ * enhancement with 4 additional modes to improve the accuracy of finite element solutions.
+ *
+ * @tparam Geometry The geometry type.
+ */
+template <typename Geometry>
+struct Q1E4
+{
+  static constexpr int strainSize         = 3;
+  static constexpr int enhancedStrainSize = 4;
+  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
+
+  Q1E4() = default;
+  explicit Q1E4(const Geometry& geometry_)
+      : geometry{std::make_shared<Geometry>(geometry_)},
+        T0InverseTransformed{calcTransformationMatrix2D(geometry_)} {}
+
+  auto calcM(const Dune::FieldVector<double, 2>& quadPos) const {
+    MType M;
+    M.setZero(strainSize, enhancedStrainSize);
+    const double xi   = quadPos[0];
+    const double eta  = quadPos[1];
+    M(0, 0)           = 2 * xi - 1.0;
+    M(1, 1)           = 2 * eta - 1.0;
+    M(2, 2)           = 2 * xi - 1.0;
+    M(2, 3)           = 2 * eta - 1.0;
+    const double detJ = geometry->integrationElement(quadPos);
+    M                 = T0InverseTransformed / detJ * M;
+    return M;
+  }
+
+  std::shared_ptr<Geometry> geometry;
+  Eigen::Matrix3d T0InverseTransformed;
+};
+
+/**
+ * @brief Structure representing EAS for Q1 with 5 enhanced strains.
+ *
+ * This structure defines the EAS for Q1 elements with 5 enhanced strains.
+ *
+ * @tparam Geometry The geometry type.
+ */
+template <typename Geometry>
+struct Q1E5
+{
+  static constexpr int strainSize         = 3;
+  static constexpr int enhancedStrainSize = 5;
+  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
+
+  Q1E5() = default;
+  explicit Q1E5(const Geometry& geometry_)
+      : geometry{std::make_shared<Geometry>(geometry_)},
+        T0InverseTransformed{calcTransformationMatrix2D(geometry_)} {}
+
+  auto calcM(const Dune::FieldVector<double, 2>& quadPos) const {
+    MType M;
+    M.setZero();
+    const double xi   = quadPos[0];
+    const double eta  = quadPos[1];
+    M(0, 0)           = 2 * xi - 1.0;
+    M(1, 1)           = 2 * eta - 1.0;
+    M(2, 2)           = 2 * xi - 1.0;
+    M(2, 3)           = 2 * eta - 1.0;
+    M(2, 4)           = (2 * xi - 1.0) * (2 * eta - 1.0);
+    const double detJ = geometry->integrationElement(quadPos);
+    M                 = T0InverseTransformed / detJ * M;
+    return M;
+  }
+
+  std::shared_ptr<Geometry> geometry;
+  Eigen::Matrix3d T0InverseTransformed;
+};
+
+/**
+ * @brief Structure representing EAS for Q1 with 7 enhanced strains.
+ *
+ * This structure defines the EAS for Q1 elements with 7 enhanced strains.
+ *
+ * @tparam Geometry The geometry type.
+ */
+template <typename Geometry>
+struct Q1E7
+{
+  static constexpr int strainSize         = 3;
+  static constexpr int enhancedStrainSize = 7;
+  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
+
+  Q1E7() = default;
+  explicit Q1E7(const Geometry& geometry_)
+      : geometry{std::make_shared<Geometry>(geometry_)},
+        T0InverseTransformed{calcTransformationMatrix2D(geometry_)} {}
+
+  auto calcM(const Dune::FieldVector<double, 2>& quadPos) const {
+    MType M;
+    M.setZero();
+    const double xi   = quadPos[0];
+    const double eta  = quadPos[1];
+    M(0, 0)           = 2 * xi - 1.0;
+    M(1, 1)           = 2 * eta - 1.0;
+    M(2, 2)           = 2 * xi - 1.0;
+    M(2, 3)           = 2 * eta - 1.0;
+    M(0, 4)           = (2 * xi - 1.0) * (2 * eta - 1.0);
+    M(1, 5)           = (2 * xi - 1.0) * (2 * eta - 1.0);
+    M(2, 6)           = (2 * xi - 1.0) * (2 * eta - 1.0);
+    const double detJ = geometry->integrationElement(quadPos);
+    M                 = T0InverseTransformed / detJ * M;
+    return M;
+  }
+
+  std::shared_ptr<Geometry> geometry;
+  Eigen::Matrix3d T0InverseTransformed;
+};
+} // namespace Ikarus::EAS

--- a/ikarus/finiteelements/mechanics/eas/eas3d.hh
+++ b/ikarus/finiteelements/mechanics/eas/eas3d.hh
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+/**
+ * @file eas3d.hh
+ * @brief Definition of the types of EAS formulations for 3D elements.
+ * @ingroup  mechanics
+ */
+
+#pragma once
+
+#include <ikarus/utils/tensorutils.hh>
+
+namespace Ikarus::EAS {
+
+/**
+ * @brief Structure representing EAS for H1 with 9 enhanced strains.
+ *
+ * This structure defines the EAS for H1 elements with 9 enhanced strains.
+ *
+ * @tparam Geometry The geometry type.
+ */
+template <typename Geometry>
+struct H1E9
+{
+  static constexpr int strainSize         = 6;
+  static constexpr int enhancedStrainSize = 9;
+  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
+
+  H1E9() = default;
+  explicit H1E9(const Geometry& geometry_)
+      : geometry{std::make_shared<Geometry>(geometry_)},
+        T0InverseTransformed{calcTransformationMatrix3D(geometry_)} {}
+
+  auto calcM(const Dune::FieldVector<double, 3>& quadPos) const {
+    MType M;
+    M.setZero();
+    const double xi   = quadPos[0];
+    const double eta  = quadPos[1];
+    const double zeta = quadPos[2];
+    M(0, 0)           = 2 * xi - 1.0;
+    M(1, 1)           = 2 * eta - 1.0;
+    M(2, 2)           = 2 * zeta - 1.0;
+    M(3, 3)           = 2 * xi - 1.0;
+    M(3, 4)           = 2 * eta - 1.0;
+    M(4, 5)           = 2 * xi - 1.0;
+    M(4, 6)           = 2 * zeta - 1.0;
+    M(5, 7)           = 2 * eta - 1.0;
+    M(5, 8)           = 2 * zeta - 1.0;
+    const double detJ = geometry->integrationElement(quadPos);
+    M                 = T0InverseTransformed / detJ * M;
+    return M;
+  }
+  std::shared_ptr<Geometry> geometry;
+  Eigen::Matrix<double, 6, 6> T0InverseTransformed;
+};
+
+/**
+ * @brief Structure representing EAS for H1 with 21 enhanced strains.
+ *
+ * This structure defines the EAS for H1 elements with 21 enhanced strains.
+ *
+ * @tparam Geometry The geometry type.
+ */
+template <typename Geometry>
+struct H1E21
+{
+  static constexpr int strainSize         = 6;
+  static constexpr int enhancedStrainSize = 21;
+  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
+
+  H1E21() = default;
+  explicit H1E21(const Geometry& geometry_)
+      : geometry{std::make_shared<Geometry>(geometry_)},
+        T0InverseTransformed{calcTransformationMatrix3D(geometry_)} {}
+
+  auto calcM(const Dune::FieldVector<double, 3>& quadPos) const {
+    MType M;
+    M.setZero();
+    const double xi   = quadPos[0];
+    const double eta  = quadPos[1];
+    const double zeta = quadPos[2];
+    M(0, 0)           = 2 * xi - 1.0;
+    M(1, 1)           = 2 * eta - 1.0;
+    M(2, 2)           = 2 * zeta - 1.0;
+    M(3, 3)           = 2 * xi - 1.0;
+    M(3, 4)           = 2 * eta - 1.0;
+    M(4, 5)           = 2 * xi - 1.0;
+    M(4, 6)           = 2 * zeta - 1.0;
+    M(5, 7)           = 2 * eta - 1.0;
+    M(5, 8)           = 2 * zeta - 1.0;
+
+    M(3, 9)  = (2 * xi - 1.0) * (2 * zeta - 1.0);
+    M(3, 10) = (2 * eta - 1.0) * (2 * zeta - 1.0);
+    M(4, 11) = (2 * xi - 1.0) * (2 * eta - 1.0);
+    M(4, 12) = (2 * eta - 1.0) * (2 * zeta - 1.0);
+    M(5, 13) = (2 * xi - 1.0) * (2 * eta - 1.0);
+    M(5, 14) = (2 * xi - 1.0) * (2 * zeta - 1.0);
+
+    M(0, 15) = (2 * xi - 1.0) * (2 * eta - 1.0);
+    M(0, 16) = (2 * xi - 1.0) * (2 * zeta - 1.0);
+    M(1, 17) = (2 * xi - 1.0) * (2 * eta - 1.0);
+    M(1, 18) = (2 * eta - 1.0) * (2 * zeta - 1.0);
+    M(2, 19) = (2 * xi - 1.0) * (2 * zeta - 1.0);
+    M(2, 20) = (2 * eta - 1.0) * (2 * zeta - 1.0);
+
+    const double detJ = geometry->integrationElement(quadPos);
+    M                 = T0InverseTransformed / detJ * M;
+    return M;
+  }
+
+  std::shared_ptr<Geometry> geometry;
+  Eigen::Matrix<double, 6, 6> T0InverseTransformed;
+};
+} // namespace Ikarus::EAS

--- a/ikarus/finiteelements/mechanics/easvariants.hh
+++ b/ikarus/finiteelements/mechanics/easvariants.hh
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+/**
+ * @file easvariants.hh
+ * @brief Definition of the EAS variants.
+ * @ingroup  mechanics
+ */
+
+#pragma once
+
+#include <ikarus/finiteelements/mechanics/eas/eas2d.hh>
+#include <ikarus/finiteelements/mechanics/eas/eas3d.hh>
+#include <ikarus/utils/tensorutils.hh>
+
+namespace Ikarus::EAS {
+/**
+ * \brief EASVariants structure holding variants of different Enhanced Assumed Strains (EAS).
+ *
+ * \details EASVariants holds the different variants of EAS formulations for
+ * both 2D and 3D elements.
+ *
+ * @tparam Geometry The geometry type.
+ */
+template <typename Geometry>
+struct Variants
+{
+  static constexpr int worldDim = Geometry::coorddimension;
+  static_assert((worldDim == 2) or (worldDim == 3), "EAS variants are only available 2D and 3D elements.");
+
+  /** \brief Variant type holding different EAS formulations for 2D elements. */
+  using EAS2D = std::variant<std::monostate, Q1E4<Geometry>, Q1E5<Geometry>, Q1E7<Geometry>>;
+
+  /** \brief Variant type holding different EAS formulations for 3D elements. */
+  using EAS3D = std::variant<std::monostate, H1E9<Geometry>, H1E21<Geometry>>;
+
+  /** \brief Type of the EAS variant depending on the grid dimension. */
+  using type = std::conditional_t<worldDim == 2, EAS2D, EAS3D>;
+};
+} // namespace Ikarus::EAS

--- a/ikarus/finiteelements/mechanics/enhancedassumedstrains.hh
+++ b/ikarus/finiteelements/mechanics/enhancedassumedstrains.hh
@@ -15,319 +15,10 @@
 
   #include <ikarus/finiteelements/fehelper.hh>
   #include <ikarus/finiteelements/ferequirements.hh>
+  #include <ikarus/finiteelements/mechanics/easvariants.hh>
   #include <ikarus/utils/eigendunetransformations.hh>
 
 namespace Ikarus {
-
-/**
- * @brief Calculates the 2D transformation matrix for Enhanced Assumed Strains (EAS).
- *
- * This function computes the transformation matrix for 2D EAS using the provided geometry.
- *
- * @tparam Geometry The geometry type.
- * @param geometry Reference to the geometry object.
- * @return Transformation matrix for 2D EAS.
- */
-template <typename Geometry>
-Eigen::Matrix3d calcTransformationMatrix2D(const Geometry& geometry) {
-  const auto& referenceElement = Dune::ReferenceElements<double, 2>::general(geometry.type());
-  const auto quadPos0          = referenceElement.position(0, 0);
-
-  const auto jacobianinvT0 = toEigen(geometry.jacobianInverseTransposed(quadPos0));
-  const auto detJ0         = geometry.integrationElement(quadPos0);
-
-  auto jaco = (jacobianinvT0).inverse().eval();
-  auto J11  = jaco(0, 0);
-  auto J12  = jaco(0, 1);
-  auto J21  = jaco(1, 0);
-  auto J22  = jaco(1, 1);
-
-  Eigen::Matrix3d T0;
-  // clang-format off
-    T0 <<      J11 * J11, J12 * J12,                   J11 * J12,
-               J21 * J21, J22 * J22,                   J21 * J22,
-         2.0 * J11 * J21, 2.0 * J12 * J22, J21 * J12 + J11 * J22;
-  // clang-format on
-  return T0.inverse() * detJ0;
-}
-
-/**
- * @brief Calculates the 3D transformation matrix for Enhanced Assumed Strains (EAS).
- *
- * This function computes the transformation matrix for 3D EAS using the provided geometry.
- *
- * @tparam Geometry The geometry type.
- * @param geometry Reference to the geometry object.
- * @return Transformation matrix for 3D EAS.
- */
-template <typename Geometry>
-Eigen::Matrix<double, 6, 6> calcTransformationMatrix3D(const Geometry& geometry) {
-  const auto& referenceElement = Dune::ReferenceElements<double, 3>::general(geometry.type());
-  const auto quadPos0          = referenceElement.position(0, 0);
-
-  const auto jacobianinvT0 = toEigen(geometry.jacobianInverseTransposed(quadPos0));
-  const auto detJ0         = geometry.integrationElement(quadPos0);
-
-  auto jaco = (jacobianinvT0).inverse().eval();
-  auto J11  = jaco(0, 0);
-  auto J12  = jaco(0, 1);
-  auto J13  = jaco(0, 2);
-  auto J21  = jaco(1, 0);
-  auto J22  = jaco(1, 1);
-  auto J23  = jaco(1, 2);
-  auto J31  = jaco(2, 0);
-  auto J32  = jaco(2, 1);
-  auto J33  = jaco(2, 2);
-
-  Eigen::Matrix<double, 6, 6> T0;
-  // clang-format off
-    T0 <<      J11 * J11,       J12 * J12,       J13 * J13,             J11 * J12,             J11 * J13,             J12 * J13,
-               J21 * J21,       J22 * J22,       J23 * J23,             J21 * J22,             J21 * J23,             J22 * J23,
-               J31 * J31,       J32 * J32,       J33 * J33,             J31 * J32,             J31 * J33,             J32 * J33,
-         2.0 * J11 * J21, 2.0 * J12 * J22, 2.0 * J13 * J23, J11 * J22 + J21 * J12, J11 * J23 + J21 * J13, J12 * J23 + J22 * J13,
-         2.0 * J11 * J31, 2.0 * J12 * J32, 2.0 * J13 * J33, J11 * J32 + J31 * J12, J11 * J33 + J31 * J13, J12 * J33 + J32 * J13,
-         2.0 * J31 * J21, 2.0 * J32 * J22, 2.0 * J33 * J23, J31 * J22 + J21 * J32, J31 * J23 + J21 * J33, J32 * J23 + J22 * J33;
-  // clang-format on
-
-  return T0.inverse() * detJ0;
-}
-
-/**
- * @brief EASQ1E4 structure for Enhanced Assumed Strains (EAS) with linear strains and 4 enhanced modes.
- *
- * \details The EASQ1E4 structure represents an implementation of Enhanced Assumed Strains (EAS)
- * for a specific case where linear strains are considered, and the method includes
- * enhancement with 4 additional modes to improve the accuracy of finite element solutions.
- *
- * @tparam Geometry The geometry type.
- */
-template <typename Geometry>
-struct EASQ1E4
-{
-  static constexpr int strainSize         = 3;
-  static constexpr int enhancedStrainSize = 4;
-  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
-
-  EASQ1E4() = default;
-  explicit EASQ1E4(const Geometry& geometry_)
-      : geometry{std::make_shared<Geometry>(geometry_)},
-        T0InverseTransformed{calcTransformationMatrix2D(geometry_)} {}
-
-  auto calcM(const Dune::FieldVector<double, 2>& quadPos) const {
-    MType M;
-    M.setZero(strainSize, enhancedStrainSize);
-    const double xi   = quadPos[0];
-    const double eta  = quadPos[1];
-    M(0, 0)           = 2 * xi - 1.0;
-    M(1, 1)           = 2 * eta - 1.0;
-    M(2, 2)           = 2 * xi - 1.0;
-    M(2, 3)           = 2 * eta - 1.0;
-    const double detJ = geometry->integrationElement(quadPos);
-    M                 = T0InverseTransformed / detJ * M;
-    return M;
-  }
-
-  std::shared_ptr<Geometry> geometry;
-  Eigen::Matrix3d T0InverseTransformed;
-};
-
-/**
- * @brief Structure representing EAS for Q1 with 5 enhanced strains.
- *
- * This structure defines the EAS for Q1 elements with 5 enhanced strains.
- *
- * @tparam Geometry The geometry type.
- */
-template <typename Geometry>
-struct EASQ1E5
-{
-  static constexpr int strainSize         = 3;
-  static constexpr int enhancedStrainSize = 5;
-  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
-
-  EASQ1E5() = default;
-  explicit EASQ1E5(const Geometry& geometry_)
-      : geometry{std::make_shared<Geometry>(geometry_)},
-        T0InverseTransformed{calcTransformationMatrix2D(geometry_)} {}
-
-  auto calcM(const Dune::FieldVector<double, 2>& quadPos) const {
-    MType M;
-    M.setZero();
-    const double xi   = quadPos[0];
-    const double eta  = quadPos[1];
-    M(0, 0)           = 2 * xi - 1.0;
-    M(1, 1)           = 2 * eta - 1.0;
-    M(2, 2)           = 2 * xi - 1.0;
-    M(2, 3)           = 2 * eta - 1.0;
-    M(2, 4)           = (2 * xi - 1.0) * (2 * eta - 1.0);
-    const double detJ = geometry->integrationElement(quadPos);
-    M                 = T0InverseTransformed / detJ * M;
-    return M;
-  }
-
-  std::shared_ptr<Geometry> geometry;
-  Eigen::Matrix3d T0InverseTransformed;
-};
-
-/**
- * @brief Structure representing EAS for Q1 with 7 enhanced strains.
- *
- * This structure defines the EAS for Q1 elements with 7 enhanced strains.
- *
- * @tparam Geometry The geometry type.
- */
-template <typename Geometry>
-struct EASQ1E7
-{
-  static constexpr int strainSize         = 3;
-  static constexpr int enhancedStrainSize = 7;
-  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
-
-  EASQ1E7() = default;
-  explicit EASQ1E7(const Geometry& geometry_)
-      : geometry{std::make_shared<Geometry>(geometry_)},
-        T0InverseTransformed{calcTransformationMatrix2D(geometry_)} {}
-
-  auto calcM(const Dune::FieldVector<double, 2>& quadPos) const {
-    MType M;
-    M.setZero();
-    const double xi   = quadPos[0];
-    const double eta  = quadPos[1];
-    M(0, 0)           = 2 * xi - 1.0;
-    M(1, 1)           = 2 * eta - 1.0;
-    M(2, 2)           = 2 * xi - 1.0;
-    M(2, 3)           = 2 * eta - 1.0;
-    M(0, 4)           = (2 * xi - 1.0) * (2 * eta - 1.0);
-    M(1, 5)           = (2 * xi - 1.0) * (2 * eta - 1.0);
-    M(2, 6)           = (2 * xi - 1.0) * (2 * eta - 1.0);
-    const double detJ = geometry->integrationElement(quadPos);
-    M                 = T0InverseTransformed / detJ * M;
-    return M;
-  }
-
-  std::shared_ptr<Geometry> geometry;
-  Eigen::Matrix3d T0InverseTransformed;
-};
-
-/**
- * @brief Structure representing EAS for H1 with 9 enhanced strains.
- *
- * This structure defines the EAS for H1 elements with 9 enhanced strains.
- *
- * @tparam Geometry The geometry type.
- */
-template <typename Geometry>
-struct EASH1E9
-{
-  static constexpr int strainSize         = 6;
-  static constexpr int enhancedStrainSize = 9;
-  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
-
-  EASH1E9() = default;
-  explicit EASH1E9(const Geometry& geometry_)
-      : geometry{std::make_shared<Geometry>(geometry_)},
-        T0InverseTransformed{calcTransformationMatrix3D(geometry_)} {}
-
-  auto calcM(const Dune::FieldVector<double, 3>& quadPos) const {
-    MType M;
-    M.setZero();
-    const double xi   = quadPos[0];
-    const double eta  = quadPos[1];
-    const double zeta = quadPos[2];
-    M(0, 0)           = 2 * xi - 1.0;
-    M(1, 1)           = 2 * eta - 1.0;
-    M(2, 2)           = 2 * zeta - 1.0;
-    M(3, 3)           = 2 * xi - 1.0;
-    M(3, 4)           = 2 * eta - 1.0;
-    M(4, 5)           = 2 * xi - 1.0;
-    M(4, 6)           = 2 * zeta - 1.0;
-    M(5, 7)           = 2 * eta - 1.0;
-    M(5, 8)           = 2 * zeta - 1.0;
-    const double detJ = geometry->integrationElement(quadPos);
-    M                 = T0InverseTransformed / detJ * M;
-    return M;
-  }
-  std::shared_ptr<Geometry> geometry;
-  Eigen::Matrix<double, 6, 6> T0InverseTransformed;
-};
-
-/**
- * @brief Structure representing EAS for H1 with 21 enhanced strains.
- *
- * This structure defines the EAS for H1 elements with 21 enhanced strains.
- *
- * @tparam Geometry The geometry type.
- */
-template <typename Geometry>
-struct EASH1E21
-{
-  static constexpr int strainSize         = 6;
-  static constexpr int enhancedStrainSize = 21;
-  using MType                             = Eigen::Matrix<double, strainSize, enhancedStrainSize>;
-
-  EASH1E21() = default;
-  explicit EASH1E21(const Geometry& geometry_)
-      : geometry{std::make_shared<Geometry>(geometry_)},
-        T0InverseTransformed{calcTransformationMatrix3D(geometry_)} {}
-
-  auto calcM(const Dune::FieldVector<double, 3>& quadPos) const {
-    MType M;
-    M.setZero();
-    const double xi   = quadPos[0];
-    const double eta  = quadPos[1];
-    const double zeta = quadPos[2];
-    M(0, 0)           = 2 * xi - 1.0;
-    M(1, 1)           = 2 * eta - 1.0;
-    M(2, 2)           = 2 * zeta - 1.0;
-    M(3, 3)           = 2 * xi - 1.0;
-    M(3, 4)           = 2 * eta - 1.0;
-    M(4, 5)           = 2 * xi - 1.0;
-    M(4, 6)           = 2 * zeta - 1.0;
-    M(5, 7)           = 2 * eta - 1.0;
-    M(5, 8)           = 2 * zeta - 1.0;
-
-    M(3, 9)  = (2 * xi - 1.0) * (2 * zeta - 1.0);
-    M(3, 10) = (2 * eta - 1.0) * (2 * zeta - 1.0);
-    M(4, 11) = (2 * xi - 1.0) * (2 * eta - 1.0);
-    M(4, 12) = (2 * eta - 1.0) * (2 * zeta - 1.0);
-    M(5, 13) = (2 * xi - 1.0) * (2 * eta - 1.0);
-    M(5, 14) = (2 * xi - 1.0) * (2 * zeta - 1.0);
-
-    M(0, 15) = (2 * xi - 1.0) * (2 * eta - 1.0);
-    M(0, 16) = (2 * xi - 1.0) * (2 * zeta - 1.0);
-    M(1, 17) = (2 * xi - 1.0) * (2 * eta - 1.0);
-    M(1, 18) = (2 * eta - 1.0) * (2 * zeta - 1.0);
-    M(2, 19) = (2 * xi - 1.0) * (2 * zeta - 1.0);
-    M(2, 20) = (2 * eta - 1.0) * (2 * zeta - 1.0);
-
-    const double detJ = geometry->integrationElement(quadPos);
-    M                 = T0InverseTransformed / detJ * M;
-    return M;
-  }
-
-  std::shared_ptr<Geometry> geometry;
-  Eigen::Matrix<double, 6, 6> T0InverseTransformed;
-};
-
-/**
- * @brief Variant type for 2D EAS structures.
- *
- * This variant type holds different EAS structures for 2D elements.
- *
- * @tparam Geometry The geometry type.
- */
-template <typename Geometry>
-using EAS2DVariant = std::variant<std::monostate, EASQ1E4<Geometry>, EASQ1E5<Geometry>, EASQ1E7<Geometry>>;
-
-/**
- * @brief Variant type for 3D EAS structures.
- *
- * This variant type holds different EAS structures for 3D elements.
- *
- * @tparam Geometry The geometry type.
- */
-template <typename Geometry>
-using EAS3DVariant = std::variant<std::monostate, EASH1E9<Geometry>, EASH1E21<Geometry>>;
 
 /**
  * @brief Wrapper class for using Enhanced Assumed Strains (EAS) with displacement based elements.
@@ -345,6 +36,7 @@ public:
   using FERequirementType      = typename DisplacementBasedElement::FERequirementType;
   using ResultRequirementsType = typename DisplacementBasedElement::ResultRequirementsType;
   using LocalView              = typename DisplacementBasedElement::LocalView;
+  using Geometry               = typename DisplacementBasedElement::Geometry;
   using GridView               = typename DisplacementBasedElement::GridView;
   using Traits                 = typename DisplacementBasedElement::Traits;
   using DisplacementBasedElement::localView;
@@ -524,13 +216,13 @@ forward the
           easVariant_ = std::monostate();
           break;
         case 4:
-          easVariant_ = EASQ1E4(localView().element().geometry());
+          easVariant_ = EAS::Q1E4(localView().element().geometry());
           break;
         case 5:
-          easVariant_ = EASQ1E5(localView().element().geometry());
+          easVariant_ = EAS::Q1E5(localView().element().geometry());
           break;
         case 7:
-          easVariant_ = EASQ1E7(localView().element().geometry());
+          easVariant_ = EAS::Q1E7(localView().element().geometry());
           break;
         default:
           DUNE_THROW(Dune::NotImplemented, "The given EAS parameters are not available for the 2D case.");
@@ -542,10 +234,10 @@ forward the
           easVariant_ = std::monostate();
           break;
         case 9:
-          easVariant_ = EASH1E9(localView().element().geometry());
+          easVariant_ = EAS::H1E9(localView().element().geometry());
           break;
         case 21:
-          easVariant_ = EASH1E21(localView().element().geometry());
+          easVariant_ = EAS::H1E21(localView().element().geometry());
           break;
         default:
           DUNE_THROW(Dune::NotImplemented, "The given EAS parameters are not available for the 3D case.");
@@ -608,9 +300,8 @@ protected:
   }
 
 private:
-  using EAS2DVariantImpl = EAS2DVariant<typename LocalView::Element::Geometry>;
-  using EAS3DVariantImpl = EAS3DVariant<typename LocalView::Element::Geometry>;
-  std::conditional_t<Traits::mydim == 2, EAS2DVariantImpl, EAS3DVariantImpl> easVariant_;
+  using EASVariant = EAS::Variants<Geometry>::type;
+  EASVariant easVariant_;
   mutable Eigen::MatrixXd L;
   template <int enhancedStrainSize>
   void calculateDAndLMatrix(const auto& easFunction, const auto& par,

--- a/ikarus/utils/tensorutils.hh
+++ b/ikarus/utils/tensorutils.hh
@@ -322,4 +322,79 @@ auto fromVoigt(const Eigen::Matrix<ScalarType, 6, 6>& CVoigt) {
   return C;
 }
 
+/**
+ * @brief Calculates the 2D transformation matrix.
+ *
+ * @details This function computes the transformation matrix needed to transform second-order tensors
+ * represented in Voigt notation from local to global coordinate system for 2D elements.
+ *
+ * @tparam Geometry The geometry type.
+ * @param geometry Reference to the geometry object.
+ * @return The transformation matrix for 2D elements.
+ */
+template <typename Geometry>
+Eigen::Matrix3d calcTransformationMatrix2D(const Geometry& geometry) {
+  const auto& referenceElement = Dune::ReferenceElements<double, 2>::general(geometry.type());
+  const auto quadPos0          = referenceElement.position(0, 0);
+
+  const auto jacobianinvT0 = toEigen(geometry.jacobianInverseTransposed(quadPos0));
+  const auto detJ0         = geometry.integrationElement(quadPos0);
+
+  auto jaco = (jacobianinvT0).inverse().eval();
+  auto J11  = jaco(0, 0);
+  auto J12  = jaco(0, 1);
+  auto J21  = jaco(1, 0);
+  auto J22  = jaco(1, 1);
+
+  Eigen::Matrix3d T0;
+  // clang-format off
+        T0 <<      J11 * J11, J12 * J12,                   J11 * J12,
+                J21 * J21, J22 * J22,                   J21 * J22,
+                2.0 * J11 * J21, 2.0 * J12 * J22, J21 * J12 + J11 * J22;
+  // clang-format on
+  return T0.inverse() * detJ0;
+}
+
+/**
+ * @brief Calculates the 3D transformation matrix.
+ *
+ * @details This function computes the transformation matrix needed to transform second-order tensors
+ * represented in Voigt notation from local to global coordinate system for 3D elements.
+ *
+ * @tparam Geometry The geometry type.
+ * @param geometry Reference to the geometry object.
+ * @return The transformation matrix for 3D elements.
+ */
+template <typename Geometry>
+Eigen::Matrix<double, 6, 6> calcTransformationMatrix3D(const Geometry& geometry) {
+  const auto& referenceElement = Dune::ReferenceElements<double, 3>::general(geometry.type());
+  const auto quadPos0          = referenceElement.position(0, 0);
+
+  const auto jacobianinvT0 = toEigen(geometry.jacobianInverseTransposed(quadPos0));
+  const auto detJ0         = geometry.integrationElement(quadPos0);
+
+  auto jaco = (jacobianinvT0).inverse().eval();
+  auto J11  = jaco(0, 0);
+  auto J12  = jaco(0, 1);
+  auto J13  = jaco(0, 2);
+  auto J21  = jaco(1, 0);
+  auto J22  = jaco(1, 1);
+  auto J23  = jaco(1, 2);
+  auto J31  = jaco(2, 0);
+  auto J32  = jaco(2, 1);
+  auto J33  = jaco(2, 2);
+
+  Eigen::Matrix<double, 6, 6> T0;
+  // clang-format off
+        T0 <<      J11 * J11,       J12 * J12,       J13 * J13,             J11 * J12,             J11 * J13,             J12 * J13,
+                J21 * J21,       J22 * J22,       J23 * J23,             J21 * J22,             J21 * J23,             J22 * J23,
+                J31 * J31,       J32 * J32,       J33 * J33,             J31 * J32,             J31 * J33,             J32 * J33,
+                2.0 * J11 * J21, 2.0 * J12 * J22, 2.0 * J13 * J23, J11 * J22 + J21 * J12, J11 * J23 + J21 * J13, J12 * J23 + J22 * J13,
+                2.0 * J11 * J31, 2.0 * J12 * J32, 2.0 * J13 * J33, J11 * J32 + J31 * J12, J11 * J33 + J31 * J13, J12 * J33 + J32 * J13,
+                2.0 * J31 * J21, 2.0 * J32 * J22, 2.0 * J33 * J23, J31 * J22 + J21 * J32, J31 * J23 + J21 * J33, J32 * J23 + J22 * J33;
+  // clang-format on
+
+  return T0.inverse() * detJ0;
+}
+
 } // namespace Ikarus


### PR DESCRIPTION
`calcTransformationMatrix2D` and `calcTransformationMatrix3D` are functions that help to transform second-order tensors and hence are moved to the file `ikarus/utils/tensorutils.hh`. Their implementations are hard-coded for a specific case and will be generalized while handling #248. 
This PR is focusing on refactoring the file `ikarus/finiteelements/mechanics/enhancedassumedstrains.hh` by moving the variants of EAS to different files for better readability of code.