### PR TITLE
merge FETraits and TraitsFromFE to avoid code duplication

### DIFF
--- a/docs/website/02_examples/incompressibleRubberBlock.md
+++ b/docs/website/02_examples/incompressibleRubberBlock.md
@@ -15,7 +15,7 @@ The `struct` named `Solid` is created which is not inherited from any class. It 
 
 ```cpp
 Solid(const Basis &basis, const typename LocalView::Element &element, double emod, double nu)
-    : localView_{basis.flat().localView()}, emod_{emod}, nu_{nu} {
+    : localView_{basis.localView()}, emod_{emod}, nu_{nu} {
   localView_.bind(element);
   mu_       = emod_ / (2 * (1 + nu_));
   lambdaMat = convertLameConstants({.emodul = emod_, .nu = nu_}).toLamesFirstParameter();

--- a/docs/website/02_examples/kirchhoffPlate.md
+++ b/docs/website/02_examples/kirchhoffPlate.md
@@ -16,7 +16,7 @@ It is constructed as shown below:
 ```cpp
 KirchhoffPlate(const Basis &basis, const typename LocalView::Element &element, double p_Emodul, double p_nu,
                double p_thickness)
-    : BaseDisp(basis.flat(), element),
+    : BaseDisp(basis, element),
       Emodul{p_Emodul},
       nu{p_nu},
       thickness{p_thickness} {

--- a/docs/website/02_examples/vonMisesTruss.md
+++ b/docs/website/02_examples/vonMisesTruss.md
@@ -13,7 +13,7 @@ It is constructed as shown below:
 
 ```cpp
 Truss(const Basis &basis, const typename LocalView::Element &element, double p_EA)
-    : BaseDisp(basis.flat(), element), EA{p_EA} {
+    : BaseDisp(basis, element), EA{p_EA} {
   this->localView().bind(element);
 }
 ```

--- a/ikarus/finiteelements/febases/autodifffe.hh
+++ b/ikarus/finiteelements/febases/autodifffe.hh
@@ -12,7 +12,7 @@
 #include <autodiff/forward/dual/eigen.hpp>
 
 #include <ikarus/finiteelements/ferequirements.hh>
-#include <ikarus/finiteelements/physicshelper.hh>
+#include <ikarus/finiteelements/fetraits.hh>
 #include <ikarus/utils/traits.hh>
 
 namespace Ikarus {
@@ -31,11 +31,11 @@ template <typename RealFE_, typename FERequirementType_ = FERequirements<>, bool
 class AutoDiffFE : public RealFE_
 {
 public:
-  using RealFE            = RealFE_;                                              ///< Type of the base finite element.
-  using Basis             = typename RealFE::Basis;                               ///< Type of the basis.
-  using Traits            = TraitsFromFE<Basis, FERequirementType_, useEigenRef>; ///< Type traits for local view.
-  using LocalView         = typename Traits::LocalView;                           ///< Type of the local view.
-  using Element           = typename Traits::Element;                             ///< Type of the element.
+  using RealFE            = RealFE_;                                          ///< Type of the base finite element.
+  using Basis             = typename RealFE::Basis;                           ///< Type of the basis.
+  using Traits            = FETraits<Basis, FERequirementType_, useEigenRef>; ///< Type traits for local view.
+  using LocalView         = typename Traits::LocalView;                       ///< Type of the local view.
+  using Element           = typename Traits::Element;                         ///< Type of the element.
   using FERequirementType = typename Traits::FERequirementType; ///< Type of the Finite Element Requirements.
 
   /**

--- a/ikarus/finiteelements/febases/powerbasisfe.hh
+++ b/ikarus/finiteelements/febases/powerbasisfe.hh
@@ -23,11 +23,11 @@ template <typename Basis>
 class PowerBasisFE
 {
 public:
-  using RootBasis   = Basis;                          ///< Type of the root basis.
-  using LocalView   = typename Basis::LocalView;      ///< Type of the local view.
-  using GlobalIndex = typename LocalView::MultiIndex; ///< Type of the global index.
-  using GridElement = typename LocalView::Element;    ///< Type of the grid element.
-  using Traits      = FETraits<GridElement>;          ///< Type of the traits.
+  using Traits      = FETraits<Basis>;              ///< Type of the traits.
+  using RootBasis   = typename Traits::FlatBasis;   ///< Type of the root basis.
+  using LocalView   = typename Traits::LocalView;   ///< Type of the local view.
+  using GlobalIndex = typename Traits::GlobalIndex; ///< Type of the global index.
+  using GridElement = typename Traits::Element;     ///< Type of the grid element.
 
   /**
    * @brief Constructor for the PowerBasisFE class.
@@ -36,7 +36,7 @@ public:
    * @param element The local element.
    */
   explicit PowerBasisFE(const Basis& p_basis, const typename LocalView::Element& element)
-      : localView_{p_basis.localView()} {
+      : localView_{p_basis.flat().localView()} {
     static_assert(Ikarus::Concepts::PowerBasis<RootBasis>,
                   "You didn't pass a localview of a power basis to this method");
     static_assert(RootBasis::PreBasis::Node::degree() != 1, "The basis has only one children. Maybe use scalarFE.hh.");

--- a/ikarus/finiteelements/febases/scalarfe.hh
+++ b/ikarus/finiteelements/febases/scalarfe.hh
@@ -21,12 +21,13 @@ template <typename Basis_>
 class ScalarFieldFE
 {
 public:
-  using Basis                   = Basis_;                         ///< Type of the root basis.
-  using LocalView               = typename Basis::LocalView;      ///< Type of the local view.
-  using GlobalIndex             = typename LocalView::MultiIndex; ///< Type of the global index.
-  using GridElement             = typename LocalView::Element;    ///< Type of the grid element.
-  using Traits                  = FETraits<GridElement>;          ///< Type of the traits.
-  static constexpr int worlddim = Traits::worlddim;               ///< Dimension of the world space.
+  using Traits                  = FETraits<Basis_>;             ///< Type of the traits.
+  using Basis                   = typename Traits::Basis;       ///< Type of the basis.
+  using RootBasis               = typename Traits::FlatBasis;   ///< Type of the root basis.
+  using LocalView               = typename Traits::LocalView;   ///< Type of the local view.
+  using GlobalIndex             = typename Traits::GlobalIndex; ///< Type of the global index.
+  using GridElement             = typename Traits::Element;     ///< Type of the grid element.
+  static constexpr int worlddim = Traits::worlddim;             ///< Dimension of the world space.
   /**
    * @brief Constructor for the ScalarFieldFE class.
    *
@@ -34,8 +35,8 @@ public:
    * @param element The local element.
    */
   explicit ScalarFieldFE(const Basis& basis, const typename LocalView::Element& element)
-      : localView_{basis.localView()} {
-    static_assert(Basis::PreBasis::Node::CHILDREN == 0, "This is no scalar basis!");
+      : localView_{basis.flat().localView()} {
+    static_assert(RootBasis::PreBasis::Node::CHILDREN == 0, "This is no scalar basis!");
     localView_.bind(element);
   }
 

--- a/ikarus/finiteelements/fetraits.hh
+++ b/ikarus/finiteelements/fetraits.hh
@@ -8,30 +8,59 @@
 
 #pragma once
 
+#include <ikarus/finiteelements/ferequirements.hh>
 #include <ikarus/utils/concepts.hh>
 
 namespace Ikarus {
 
 /**
- * \brief Template structure defining traits for a given grid element entity type.
+ * \brief Traits for handling finite elements.
  *
- * \tparam GridElement Type of the grid element entity.
+ * \tparam Basis_ The basis type for the finite element.
+ * \tparam FERequirements_ The requirements for the finite element.
  * \tparam useRef Boolean indicating whether to use Eigen::Ref for VectorType and MatrixType.
  */
-template <typename GridElement, bool useRef = false>
+template <typename Basis_, typename FERequirements_ = FERequirements<>, bool useRef = false>
 struct FETraits
 {
+  /** \brief Type of the basis of the finite element */
+  using Basis = Basis_;
+
+  /** \brief Type of the requirements for the finite element */
+  using FERequirementType = FERequirements_;
+
+  /** \brief Type of the result requirements */
+  using ResultRequirementsType = ResultRequirements<FERequirementType>;
+
+  /** \brief Type of the flat basis */
+  using FlatBasis = typename Basis::FlatBasis;
+
+  /** \brief Type of the local view */
+  using LocalView = typename FlatBasis::LocalView;
+
+  /** \brief Type of the grid view */
+  using GridView = typename FlatBasis::GridView;
+
+  /** \brief Type of the grid element */
+  using Element = typename LocalView::Element;
+
+  /** \brief Type of the element geometry */
+  using Geometry = typename Element::Geometry;
+
+  /** \brief Type of the global index */
+  using GlobalIndex = typename LocalView::MultiIndex;
+
   /** \brief Type used for coordinates */
   using ctype = double;
 
   /** \brief Dimension of the world space */
-  static constexpr int worlddim = GridElement::Geometry::coorddimension;
+  static constexpr int worlddim = Geometry::coorddimension;
 
   /** \brief Dimension of the geometry */
-  static constexpr int mydim = GridElement::mydimension;
+  static constexpr int mydim = Element::mydimension;
 
   /** \brief Dimension of the grid */
-  static constexpr int dimension = GridElement::dimension;
+  static constexpr int dimension = Element::dimension;
 
   /** \brief Type of the  coordinate */
   using GlobalCoordinates = Eigen::Matrix<ctype, worlddim, 1>;
@@ -40,13 +69,12 @@ struct FETraits
   using ParameterSpaceType = Eigen::Matrix<ctype, mydim, 1>;
 
   /** \brief Type of the internal forces */
-  using VectorType = std::conditional_t<useRef, Eigen::Ref<Eigen::VectorXd>, Eigen::VectorXd>;
-
-  /** \brief Type of the internal forces */
-  using ScalarType = ctype;
+  template <typename ScalarType = ctype>
+  using VectorType = std::conditional_t<useRef, Eigen::Ref<Eigen::VectorX<ScalarType>>, Eigen::VectorX<ScalarType>&>;
 
   /** \brief Type of the stiffness matrix */
-  using MatrixType = std::conditional_t<useRef, Eigen::Ref<Eigen::MatrixXd>, Eigen::MatrixXd>;
+  template <typename ScalarType = ctype>
+  using MatrixType = std::conditional_t<useRef, Eigen::Ref<Eigen::MatrixX<ScalarType>>, Eigen::MatrixX<ScalarType>&>;
 };
 
 } // namespace Ikarus

--- a/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
+++ b/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
@@ -36,14 +36,14 @@ namespace Ikarus {
  * @tparam useEigenRef A boolean indicating whether to use Eigen references for efficiency.
  */
 template <typename Basis_, typename FERequirements_ = FERequirements<>, bool useEigenRef = false>
-class KirchhoffLoveShell : public PowerBasisFE<typename Basis_::FlatBasis>,
+class KirchhoffLoveShell : public PowerBasisFE<Basis_>,
                            public Volume<KirchhoffLoveShell<Basis_, FERequirements_, useEigenRef>,
-                                         TraitsFromFE<Basis_, FERequirements_, useEigenRef>>,
+                                         FETraits<Basis_, FERequirements_, useEigenRef>>,
                            public Traction<KirchhoffLoveShell<Basis_, FERequirements_, useEigenRef>,
-                                           TraitsFromFE<Basis_, FERequirements_, useEigenRef>>
+                                           FETraits<Basis_, FERequirements_, useEigenRef>>
 {
 public:
-  using Traits                 = TraitsFromFE<Basis_, FERequirements_, useEigenRef>;
+  using Traits                 = FETraits<Basis_, FERequirements_, useEigenRef>;
   using Basis                  = typename Traits::Basis;
   using FlatBasis              = typename Traits::FlatBasis;
   using FERequirementType      = typename Traits::FERequirementType;
@@ -52,7 +52,7 @@ public:
   using GridView               = typename Traits::GridView;
   using Element                = typename Traits::Element;
   using ResultRequirementsType = typename Traits::ResultRequirementsType;
-  using BasePowerFE            = PowerBasisFE<FlatBasis>; // Handles globalIndices function
+  using BasePowerFE            = PowerBasisFE<Basis>; // Handles globalIndices function
   using VolumeType             = Volume<KirchhoffLoveShell<Basis_, FERequirements_, useEigenRef>, Traits>;
   using TractionType           = Traction<KirchhoffLoveShell<Basis_, FERequirements_, useEigenRef>, Traits>;
   using LocalBasisType         = decltype(std::declval<LocalView>().tree().child(0).finiteElement().localBasis());
@@ -106,7 +106,7 @@ public:
                      double thickness, VolumeLoad p_volumeLoad = {},
                      const BoundaryPatch<GridView>* p_neumannBoundary = nullptr,
                      NeumannBoundaryLoad p_neumannBoundaryLoad        = {})
-      : BasePowerFE(globalBasis.flat(), element),
+      : BasePowerFE(globalBasis, element),
         VolumeType(p_volumeLoad),
         TractionType(p_neumannBoundary, p_neumannBoundaryLoad),
         emod_{emod},

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -24,6 +24,7 @@
   #include <ikarus/finiteelements/febases/powerbasisfe.hh>
   #include <ikarus/finiteelements/fehelper.hh>
   #include <ikarus/finiteelements/ferequirements.hh>
+  #include <ikarus/finiteelements/fetraits.hh>
   #include <ikarus/finiteelements/mechanics/loads.hh>
   #include <ikarus/finiteelements/mechanics/materials.hh>
   #include <ikarus/finiteelements/physicshelper.hh>
@@ -42,14 +43,14 @@ namespace Ikarus {
  * @tparam useEigenRef A boolean flag indicating whether to use Eigen references.
  */
 template <typename Basis_, typename FERequirements_ = FERequirements<>, bool useEigenRef = false>
-class LinearElastic : public PowerBasisFE<typename Basis_::FlatBasis>,
+class LinearElastic : public PowerBasisFE<Basis_>,
                       public Volume<LinearElastic<Basis_, FERequirements_, useEigenRef>,
-                                    TraitsFromFE<Basis_, FERequirements_, useEigenRef>>,
+                                    FETraits<Basis_, FERequirements_, useEigenRef>>,
                       public Traction<LinearElastic<Basis_, FERequirements_, useEigenRef>,
-                                      TraitsFromFE<Basis_, FERequirements_, useEigenRef>>
+                                      FETraits<Basis_, FERequirements_, useEigenRef>>
 {
 public:
-  using Traits                 = TraitsFromFE<Basis_, FERequirements_, useEigenRef>;
+  using Traits                 = FETraits<Basis_, FERequirements_, useEigenRef>;
   using Basis                  = typename Traits::Basis;
   using FlatBasis              = typename Traits::FlatBasis;
   using FERequirementType      = typename Traits::FERequirementType;
@@ -58,7 +59,7 @@ public:
   using GridView               = typename Traits::GridView;
   using Element                = typename Traits::Element;
   using ResultRequirementsType = typename Traits::ResultRequirementsType;
-  using BaseDisp               = PowerBasisFE<FlatBasis>; // Handles globalIndices function
+  using BaseDisp               = PowerBasisFE<Basis>; // Handles globalIndices function
   using VolumeType             = Volume<LinearElastic<Basis_, FERequirements_, useEigenRef>, Traits>;
   using TractionType           = Traction<LinearElastic<Basis_, FERequirements_, useEigenRef>, Traits>;
   static constexpr int myDim   = Traits::mydim;
@@ -81,7 +82,7 @@ public:
   LinearElastic(const Basis& globalBasis, const typename LocalView::Element& element, double emod, double nu,
                 VolumeLoad p_volumeLoad = {}, const BoundaryPatch<GridView>* p_neumannBoundary = nullptr,
                 NeumannBoundaryLoad p_neumannBoundaryLoad = {})
-      : BaseDisp(globalBasis.flat(), element),
+      : BaseDisp(globalBasis, element),
         VolumeType(p_volumeLoad),
         TractionType(p_neumannBoundary, p_neumannBoundaryLoad),
         emod_{emod},

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -21,6 +21,7 @@
   #include <ikarus/finiteelements/febases/powerbasisfe.hh>
   #include <ikarus/finiteelements/fehelper.hh>
   #include <ikarus/finiteelements/ferequirements.hh>
+  #include <ikarus/finiteelements/fetraits.hh>
   #include <ikarus/finiteelements/mechanics/loads.hh>
   #include <ikarus/finiteelements/mechanics/materials/tags.hh>
   #include <ikarus/finiteelements/physicshelper.hh>
@@ -41,14 +42,14 @@ namespace Ikarus {
  * @tparam useEigenRef A boolean flag indicating whether to use Eigen references.
  */
 template <typename Basis_, typename Material_, typename FERequirements_ = FERequirements<>, bool useEigenRef = false>
-class NonLinearElastic : public PowerBasisFE<typename Basis_::FlatBasis>,
+class NonLinearElastic : public PowerBasisFE<Basis_>,
                          public Volume<NonLinearElastic<Basis_, Material_, FERequirements_, useEigenRef>,
-                                       TraitsFromFE<Basis_, FERequirements_, useEigenRef>>,
+                                       FETraits<Basis_, FERequirements_, useEigenRef>>,
                          public Traction<NonLinearElastic<Basis_, Material_, FERequirements_, useEigenRef>,
-                                         TraitsFromFE<Basis_, FERequirements_, useEigenRef>>
+                                         FETraits<Basis_, FERequirements_, useEigenRef>>
 {
 public:
-  using Traits                 = TraitsFromFE<Basis_, FERequirements_, useEigenRef>;
+  using Traits                 = FETraits<Basis_, FERequirements_, useEigenRef>;
   using Basis                  = typename Traits::Basis;
   using FlatBasis              = typename Traits::FlatBasis;
   using FERequirementType      = typename Traits::FERequirementType;
@@ -57,7 +58,7 @@ public:
   using GridView               = typename Traits::GridView;
   using Element                = typename Traits::Element;
   using ResultRequirementsType = typename Traits::ResultRequirementsType;
-  using BasePowerFE            = PowerBasisFE<FlatBasis>; // Handles globalIndices function
+  using BasePowerFE            = PowerBasisFE<Basis>; // Handles globalIndices function
   using Material               = Material_;
   using VolumeType             = Volume<NonLinearElastic<Basis_, Material_, FERequirements_, useEigenRef>, Traits>;
   using TractionType           = Traction<NonLinearElastic<Basis_, Material_, FERequirements_, useEigenRef>, Traits>;
@@ -82,7 +83,7 @@ public:
   NonLinearElastic(const Basis& globalBasis, const typename LocalView::Element& element, const Material& p_mat,
                    VolumeLoad p_volumeLoad = {}, const BoundaryPatch<GridView>* p_neumannBoundary = nullptr,
                    NeumannBoundaryLoad p_neumannBoundaryLoad = {})
-      : BasePowerFE(globalBasis.flat(), element),
+      : BasePowerFE(globalBasis, element),
         VolumeType(p_volumeLoad),
         TractionType(p_neumannBoundary, p_neumannBoundaryLoad),
         mat{p_mat} {

--- a/ikarus/finiteelements/physicshelper.hh
+++ b/ikarus/finiteelements/physicshelper.hh
@@ -11,8 +11,6 @@
 #include <dune/common/float_cmp.hh>
 
 #include <Eigen/Core>
-
-#include <ikarus/finiteelements/ferequirements.hh>
 namespace Ikarus {
 
 /**
@@ -56,58 +54,6 @@ namespace Ikarus {
   C *= E / ((1 + nu) * (1 - 2 * nu));
   return C;
 }
-
-/**
- * \brief Traits for handling finite elements.
- *
- * \tparam Basis_ The basis type for the finite element.
- * \tparam FERequirements_ The requirements for the finite element.
- * \tparam useRef Boolean indicating whether to use Eigen::Ref for VectorType and MatrixType.
- */
-template <typename Basis_, typename FERequirements_, bool useRef = false>
-struct TraitsFromFE
-{
-  /** \brief Type of the basis of the finite element */
-  using Basis = Basis_;
-
-  /** \brief Type of the requirements for the finite element */
-  using FERequirementType = FERequirements_;
-
-  /** \brief Type of the result requirements */
-  using ResultRequirementsType = ResultRequirements<FERequirementType>;
-
-  /** \brief Type of the flat basis */
-  using FlatBasis = typename Basis::FlatBasis;
-
-  /** \brief Type of the local view */
-  using LocalView = typename FlatBasis::LocalView;
-
-  /** \brief Type of the grid view */
-  using GridView = typename FlatBasis::GridView;
-
-  /** \brief Type of the grid element */
-  using Element = typename LocalView::Element;
-
-  /** \brief Type of the element geometry */
-  using Geometry = typename Element::Geometry;
-
-  /** \brief Dimension of the world space */
-  static constexpr int worlddim = Element::Geometry::coorddimension;
-
-  /** \brief Dimension of the geometry */
-  static constexpr int mydim = Element::mydimension;
-
-  /** \brief Dimension of the grid */
-  static constexpr int dimension = Element::dimension;
-
-  /** \brief Type of the internal forces */
-  template <typename ScalarType = double>
-  using VectorType = std::conditional_t<useRef, Eigen::Ref<Eigen::VectorX<ScalarType>>, Eigen::VectorX<ScalarType>&>;
-
-  /** \brief Type of the stiffness matrix */
-  template <typename ScalarType = double>
-  using MatrixType = std::conditional_t<useRef, Eigen::Ref<Eigen::MatrixX<ScalarType>>, Eigen::MatrixX<ScalarType>&>;
-};
 
 ///< Structure representing Young's modulus and Poisson's ratio. \brief see
 ///< https://en.wikipedia.org/wiki/Lam%C3%A9_parameters

--- a/tests/src/checkfebyautodiff.hh
+++ b/tests/src/checkfebyautodiff.hh
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
+#include <dune/common/float_cmp.hh>
 #include <dune/common/test/testsuite.hh>
 
 #include <Eigen/Core>


### PR DESCRIPTION
This PR focuses on merging `FETraits` and `TraitsFromFE` to avoid duplication of code. It also now handles `basis.flat()` in `PowerBasisFE` and `ScalarFieldFE` such that this need not be repeated in the constructor of every finite element.