### PR TITLE
Rework Type Traits for `calculateAt()` Function + add function to element if result can be provided

### DIFF
--- a/ikarus/finiteelements/CMakeLists.txt
+++ b/ikarus/finiteelements/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # install headers
-install(FILES ferequirements.hh fetraits.hh fehelper.hh physicshelper.hh
+install(FILES ferequirements.hh fetraits.hh fehelper.hh physicshelper.hh feresulttypes.hh
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements
 )
 

--- a/ikarus/finiteelements/ferequirements.hh
+++ b/ikarus/finiteelements/ferequirements.hh
@@ -18,8 +18,8 @@
 
 #include <Eigen/Core>
 
-#include <ikarus/utils/makeenum.hh>
 #include <ikarus/finiteelements/feresulttypes.hh>
+#include <ikarus/utils/makeenum.hh>
 
 namespace Ikarus {
 // clang-format off
@@ -85,7 +85,6 @@ namespace Ikarus {
       );
 
 // clang-format on
-
 
 /**
  * \brief Struct representing a collection of affordances.

--- a/ikarus/finiteelements/ferequirements.hh
+++ b/ikarus/finiteelements/ferequirements.hh
@@ -19,6 +19,7 @@
 #include <Eigen/Core>
 
 #include <ikarus/utils/makeenum.hh>
+#include <ikarus/finiteelements/feresulttypes.hh>
 
 namespace Ikarus {
 // clang-format off
@@ -83,26 +84,8 @@ namespace Ikarus {
             magnetizationAndVectorPotential
       );
 
-  /**
-*
-* \ingroup FEParameterTags
-* \brief A strongly typed enum class representing the type of the result request
-*/
-  MAKE_ENUM(ResultType,
-            noType,
-            magnetization,
-            gradientNormOfMagnetization,
-            vectorPotential,
-            divergenceOfVectorPotential,
-            BField,
-            HField,
-            cauchyStress,
-            PK2Stress,
-            linearStress,
-            director
-      );
-
 // clang-format on
+
 
 /**
  * \brief Struct representing a collection of affordances.
@@ -333,7 +316,7 @@ public:
   }
 };
 
-template <typename Type>
-concept ResultTypeConcept = std::is_same_v<Type, ResultType>;
+// template <typename Type>
+// concept ResultTypeConcept = std::is_same_v<Type, ResultType>;
 
 } // namespace Ikarus

--- a/ikarus/finiteelements/feresulttypes.hh
+++ b/ikarus/finiteelements/feresulttypes.hh
@@ -1,28 +1,31 @@
 // SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-
 #pragma once
 
 #include <ikarus/utils/math.hh>
 /**
-*
-* \ingroup FEParameterTags
-* \brief A strongly typed enum class representing the type of the result request
-*/
+ *
+ * \ingroup FEParameterTags
+ * \brief A strongly typed enum class representing the type of the result request
+ */
 
-
-namespace Ikarus::ResultType
-{
+namespace Ikarus::ResultType {
 #define REGISTER_RT(structName) \
-friend auto toString(structName){return #structName;}
+  friend auto toString(structName) { return #structName; }
 
 namespace Impl {
   template <int dim>
-  constexpr int matrixSize() {
-    return (-1 + Ikarus::ct_sqrt(1 + 8 * dim)) / 2;
+  constexpr int voigtSize() {
+    return dim * (dim + 1) / 2;
   }
-}
+
+  template <int dim>
+  constexpr int matrixSize() {
+    return (-1 + ct_sqrt(1 + 8 * voigtSize<dim>())) / 2;
+  }
+
+} // namespace Impl
 
 struct noType;
 struct magnetization;
@@ -35,6 +38,7 @@ struct cauchyStress;
 struct PK2Stress;
 struct linearStress;
 struct director;
+struct customType;
 
 struct noType
 {
@@ -69,20 +73,87 @@ struct HField
 struct cauchyStress
 {
   REGISTER_RT(cauchyStress);
+
+  static constexpr bool voigtApplicable = true;
+
+  template <int gridDim>
+  using matrixType = Eigen::Matrix<double, Impl::matrixSize<gridDim>(), Impl::matrixSize<gridDim>()>;
+
+  template <int gridDim>
+  using voigtType = Eigen::Vector<double, Impl::voigtSize<gridDim>()>;
+
+  template <int gridDim, bool voigt>
+  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
 };
 struct PK2Stress
 {
   REGISTER_RT(PK2Stress);
+
+  static constexpr bool voigtApplicable = true;
+
+  template <int gridDim>
+  using matrixType = Eigen::Matrix<double, Impl::matrixSize<gridDim>(), Impl::matrixSize<gridDim>()>;
+
+  template <int gridDim>
+  using voigtType = Eigen::Vector<double, Impl::voigtSize<gridDim>()>;
+
+  template <int gridDim, bool voigt>
+  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
 };
 struct linearStress
 {
   REGISTER_RT(linearStress);
 
+  static constexpr bool voigtApplicable = true;
+
+  template <int gridDim>
+  using matrixType = Eigen::Matrix<double, Impl::matrixSize<gridDim>(), Impl::matrixSize<gridDim>()>;
+
+  template <int gridDim>
+  using voigtType = Eigen::Vector<double, Impl::voigtSize<gridDim>()>;
+
+  template <int gridDim, bool voigt>
+  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
 };
 struct director
 {
   REGISTER_RT(director);
 
+  static constexpr bool voigtApplicable = false;
+
+  template <int gridDim>
+  using type = Eigen::Vector<double, gridDim>;
 };
 
-}
+struct customType
+{
+  REGISTER_RT(customType);
+
+  template <int gridDim>
+  using type = Eigen::MatrixXd;
+};
+
+} // namespace Ikarus::ResultType
+
+namespace Ikarus {
+
+template <typename RT>
+concept HasVoigt = std::same_as<RT, ResultType::linearStress> || std::same_as<RT, ResultType::cauchyStress> ||
+                   std::same_as<RT, ResultType::PK2Stress>;
+
+template <typename RT, int gridDim, bool voigt>
+struct getResultType
+{
+  using type = typename RT::template type<gridDim>;
+};
+
+template <HasVoigt RT, int gridDim, bool voigt>
+struct getResultType<RT, gridDim, voigt>
+{
+  using type = typename RT::template type<gridDim, voigt>;
+};
+
+template <typename RT, int gridDim, bool voigt = true>
+using resultType_t = typename getResultType<RT, gridDim, voigt>::type;
+
+} // namespace Ikarus

--- a/ikarus/finiteelements/feresulttypes.hh
+++ b/ikarus/finiteelements/feresulttypes.hh
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+
+#pragma once
+
+#include <ikarus/utils/math.hh>
+/**
+*
+* \ingroup FEParameterTags
+* \brief A strongly typed enum class representing the type of the result request
+*/
+
+
+namespace Ikarus::ResultType
+{
+#define REGISTER_RT(structName) \
+friend auto toString(structName){return #structName;}
+
+namespace Impl {
+  template <int dim>
+  constexpr int matrixSize() {
+    return (-1 + Ikarus::ct_sqrt(1 + 8 * dim)) / 2;
+  }
+}
+
+struct noType;
+struct magnetization;
+struct gradientNormOfMagnetization;
+struct vectorPotential;
+struct divergenceOfVectorPotential;
+struct BField;
+struct HField;
+struct cauchyStress;
+struct PK2Stress;
+struct linearStress;
+struct director;
+
+struct noType
+{
+  REGISTER_RT(noType);
+};
+
+struct magnetization
+{
+  REGISTER_RT(magnetization);
+};
+
+struct gradientNormOfMagnetization
+{
+  REGISTER_RT(gradientNormOfMagnetization);
+};
+struct vectorPotential
+{
+  REGISTER_RT(vectorPotential);
+};
+struct divergenceOfVectorPotential
+{
+  REGISTER_RT(divergenceOfVectorPotential);
+};
+struct BField
+{
+  REGISTER_RT(BField);
+};
+struct HField
+{
+  REGISTER_RT(HField);
+};
+struct cauchyStress
+{
+  REGISTER_RT(cauchyStress);
+};
+struct PK2Stress
+{
+  REGISTER_RT(PK2Stress);
+};
+struct linearStress
+{
+  REGISTER_RT(linearStress);
+
+};
+struct director
+{
+  REGISTER_RT(director);
+
+};
+
+}

--- a/ikarus/finiteelements/feresulttypes.hh
+++ b/ikarus/finiteelements/feresulttypes.hh
@@ -14,7 +14,7 @@ namespace Ikarus::ResultType {
 #define REGISTER_RT(structName) \
   friend auto toString(structName) { return #structName; }
 
-namespace Impl {
+namespace Util {
   template <int dim>
   constexpr int voigtSize() {
     return dim * (dim + 1) / 2;
@@ -25,24 +25,67 @@ namespace Impl {
     return (-1 + ct_sqrt(1 + 8 * voigtSize<dim>())) / 2;
   }
 
-} // namespace Impl
-
-struct noType;
-struct magnetization;
-struct gradientNormOfMagnetization;
-struct vectorPotential;
-struct divergenceOfVectorPotential;
-struct BField;
-struct HField;
-struct cauchyStress;
-struct PK2Stress;
-struct linearStress;
-struct director;
-struct customType;
+} // namespace Util
 
 struct noType
 {
   REGISTER_RT(noType);
+};
+
+struct linearStress
+{
+  REGISTER_RT(linearStress);
+
+  using voigtApplicable = std::true_type;
+
+  template <int dim>
+  using matrixType = Eigen::Matrix<double, Util::matrixSize<dim>(), Util::matrixSize<dim>()>;
+
+  template <int dim>
+  using voigtType = Eigen::Vector<double, Util::voigtSize<dim>()>;
+
+  template <int gridDim, int worldDim, bool voigt>
+  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
+};
+
+struct PK2Stress
+{
+  REGISTER_RT(PK2Stress);
+
+  using voigtApplicable = std::true_type;
+
+  template <int dim>
+  using matrixType = Eigen::Matrix<double, Util::matrixSize<dim>(), Util::matrixSize<dim>()>;
+
+  template <int dim>
+  using voigtType = Eigen::Vector<double, Util::voigtSize<dim>()>;
+
+  template <int gridDim, int worldDim, bool voigt>
+  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
+};
+
+struct cauchyStress
+{
+  REGISTER_RT(cauchyStress);
+
+  using voigtApplicable = std::true_type;
+
+  template <int dim>
+  using matrixType = Eigen::Matrix<double, Util::matrixSize<dim>(), Util::matrixSize<dim>()>;
+
+  template <int dim>
+  using voigtType = Eigen::Vector<double, Util::voigtSize<dim>()>;
+
+  template <int gridDim, int worldDim, bool voigt>
+  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
+};
+
+struct director
+{
+  REGISTER_RT(director);
+
+  template <int gridDim, int worldDim>
+  using type = Eigen::Vector<double, worldDim>;
 };
 
 struct magnetization
@@ -54,106 +97,60 @@ struct gradientNormOfMagnetization
 {
   REGISTER_RT(gradientNormOfMagnetization);
 };
+
 struct vectorPotential
 {
   REGISTER_RT(vectorPotential);
 };
+
 struct divergenceOfVectorPotential
 {
   REGISTER_RT(divergenceOfVectorPotential);
 };
+
 struct BField
 {
   REGISTER_RT(BField);
 };
+
 struct HField
 {
   REGISTER_RT(HField);
-};
-struct cauchyStress
-{
-  REGISTER_RT(cauchyStress);
-
-  static constexpr bool voigtApplicable = true;
-
-  template <int gridDim>
-  using matrixType = Eigen::Matrix<double, Impl::matrixSize<gridDim>(), Impl::matrixSize<gridDim>()>;
-
-  template <int gridDim>
-  using voigtType = Eigen::Vector<double, Impl::voigtSize<gridDim>()>;
-
-  template <int gridDim, bool voigt>
-  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
-};
-struct PK2Stress
-{
-  REGISTER_RT(PK2Stress);
-
-  static constexpr bool voigtApplicable = true;
-
-  template <int gridDim>
-  using matrixType = Eigen::Matrix<double, Impl::matrixSize<gridDim>(), Impl::matrixSize<gridDim>()>;
-
-  template <int gridDim>
-  using voigtType = Eigen::Vector<double, Impl::voigtSize<gridDim>()>;
-
-  template <int gridDim, bool voigt>
-  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
-};
-struct linearStress
-{
-  REGISTER_RT(linearStress);
-
-  static constexpr bool voigtApplicable = true;
-
-  template <int gridDim>
-  using matrixType = Eigen::Matrix<double, Impl::matrixSize<gridDim>(), Impl::matrixSize<gridDim>()>;
-
-  template <int gridDim>
-  using voigtType = Eigen::Vector<double, Impl::voigtSize<gridDim>()>;
-
-  template <int gridDim, bool voigt>
-  using type = std::conditional_t<voigt, voigtType<gridDim>, matrixType<gridDim>>;
-};
-struct director
-{
-  REGISTER_RT(director);
-
-  static constexpr bool voigtApplicable = false;
-
-  template <int gridDim>
-  using type = Eigen::Vector<double, gridDim>;
 };
 
 struct customType
 {
   REGISTER_RT(customType);
 
-  template <int gridDim>
+  template <int gridDim, int worldDim>
   using type = Eigen::MatrixXd;
 };
+
+template <typename RT>
+concept ResultTypeConcept = requires(RT t) {
+  { toString(t) } -> std::convertible_to<std::string>;
+};
+
+template <typename RT>
+concept HasVoigt = std::is_same_v<typename RT::voigtApplicable, std::true_type> && ResultTypeConcept<RT>;
 
 } // namespace Ikarus::ResultType
 
 namespace Ikarus {
 
-template <typename RT>
-concept HasVoigt = std::same_as<RT, ResultType::linearStress> || std::same_as<RT, ResultType::cauchyStress> ||
-                   std::same_as<RT, ResultType::PK2Stress>;
-
-template <typename RT, int gridDim, bool voigt>
+template <typename RT, int gridDim, int worldDim, bool>
 struct getResultType
 {
-  using type = typename RT::template type<gridDim>;
+  using type = typename RT::template type<gridDim, worldDim>;
 };
 
-template <HasVoigt RT, int gridDim, bool voigt>
-struct getResultType<RT, gridDim, voigt>
+template <ResultType::HasVoigt RT, int gridDim, int worldDim, bool voigt>
+struct getResultType<RT, gridDim, worldDim, voigt>
 {
-  using type = typename RT::template type<gridDim, voigt>;
+  using type = typename RT::template type<gridDim, worldDim, voigt>;
 };
 
-template <typename RT, int gridDim, bool voigt = true>
-using resultType_t = typename getResultType<RT, gridDim, voigt>::type;
+template <typename RT, int gridDim, int worldDim = gridDim, bool voigt = true>
+using resultType_t = typename getResultType<RT, gridDim, worldDim, voigt>::type;
 
 } // namespace Ikarus

--- a/ikarus/finiteelements/feresulttypes.hh
+++ b/ikarus/finiteelements/feresulttypes.hh
@@ -138,7 +138,7 @@ concept HasVoigt = std::is_same_v<typename RT::voigtApplicable, std::true_type> 
 
 namespace Ikarus {
 
-template <typename RT, int gridDim, int worldDim, bool>
+template <ResultType::ResultTypeConcept RT, int gridDim, int worldDim, bool>
 struct getResultType
 {
   using type = typename RT::template type<gridDim, worldDim>;
@@ -150,7 +150,7 @@ struct getResultType<RT, gridDim, worldDim, voigt>
   using type = typename RT::template type<gridDim, worldDim, voigt>;
 };
 
-template <typename RT, int gridDim, int worldDim = gridDim, bool voigt = true>
+template <ResultType::ResultTypeConcept RT, int gridDim, int worldDim = gridDim, bool voigt = true>
 using resultType_t = typename getResultType<RT, gridDim, worldDim, voigt>::type;
 
 } // namespace Ikarus

--- a/ikarus/finiteelements/mechanics/enhancedassumedstrains.hh
+++ b/ikarus/finiteelements/mechanics/enhancedassumedstrains.hh
@@ -160,13 +160,13 @@ forward the
    *
    * \tparam resType The type representing the requested result.
    */
-  template <ResultType resType>
+  template <typename resType>
   auto calculateAt(const FERequirementType& req, const Dune::FieldVector<double, Traits::mydim>& local) const {
     using namespace Dune::Indices;
     using namespace Dune::DerivativeDirections;
     using namespace Dune;
 
-    static_assert(resType == ResultType::linearStress, "The requested result type is NOT implemented.");
+    // static_assert(resType == ResultType::linearStress, "The requested result type is NOT implemented.");
 
     auto resultVector = DisplacementBasedElement::template calculateAt<resType>(req, local);
 

--- a/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
+++ b/ikarus/finiteelements/mechanics/kirchhoffloveshell.hh
@@ -189,12 +189,23 @@ public:
    * \param local Local position vector.
    * \return calculated result
    *
-   * \tparam resType The type representing the requested result.
+   * \tparam RT The type representing the requested result.
+   * \tparam voigt Returns result in Voigt notation (if applicable)
    */
-  template <ResultType resType>
+  template <typename RT, bool voigt = true>
   auto calculateAt([[maybe_unused]] const FERequirementType& req,
                    [[maybe_unused]] const Dune::FieldVector<double, Traits::mydim>& local) const {
     DUNE_THROW(Dune::NotImplemented, "No results are implemented");
+  }
+
+  /**
+   * \brief Returns whether an element can provide a requested result. Can be used in constant expressions
+   * \tparam RT The type representing the requested result.
+   * \return boolean indicating if a requested result can be provided
+   */
+  template <typename RT>
+  static constexpr bool canProvideResultType() {
+    return false;
   }
 
 private:

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -62,6 +62,9 @@ public:
   static constexpr int myDim = Traits::mydim;
   using LocalBasisType       = decltype(std::declval<LocalView>().tree().child(0).finiteElement().localBasis());
 
+  template <typename RT, bool voigt = true>
+  using ResultTypeType = resultType_t<RT, myDim, Traits::worlddim, voigt>;
+
   /**
    * \brief Constructor for the LinearElastic class.
    *
@@ -211,10 +214,11 @@ public:
    * \return calculated result
    *
    * \tparam RT The type representing the requested result.
+   * \tparam voigt Returns result in Voigt notation (if applicable)
    */
   template <typename RT, bool voigt = true>
   auto calculateAt(const FERequirementType& req, const Dune::FieldVector<double, Traits::mydim>& local) const
-      -> resultType_t<RT, myDim, voigt> {
+      -> ResultTypeType<RT, voigt> {
     if constexpr (std::is_same_v<RT, ResultType::linearStress>) {
       const auto eps = strainFunction(req);
       const auto C   = materialTangent();
@@ -223,8 +227,6 @@ public:
         return (C * epsVoigt).eval();
       else
         return fromVoigt((C * epsVoigt).eval(), false);
-    } else if constexpr (std::is_same_v<RT, ResultType::director>) {
-      return resultType_t<RT, myDim>::Zero();
     } else
       static_assert(Dune::AlwaysFalse<RT>::value, "The requested result type is NOT implemented.");
     __builtin_unreachable();
@@ -232,11 +234,7 @@ public:
 
   template <typename RT>
   static constexpr bool canProvideResultType() {
-    if constexpr (std::is_same_v<RT, ResultType::linearStress>)
-      return true;
-    if constexpr (std::is_same_v<RT, ResultType::director>)
-      return true;
-    return false;
+    return static_cast<bool>(std::is_same_v<RT, ResultType::linearStress>);
   }
 
 private:

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -225,6 +225,14 @@ public:
     }
   }
 
+  template <ResultType resultType>
+  static constexpr bool canProvideResultType() {
+    if constexpr (resultType == ResultType::linearStress)
+      return true;
+    else
+      return false;
+  }
+
 private:
   std::shared_ptr<const Geometry> geo_;
   Dune::CachedLocalBasis<std::remove_cvref_t<LocalBasisType>> localBasis_;

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -232,6 +232,11 @@ public:
     __builtin_unreachable();
   }
 
+  /**
+   * \brief Returns whether an element can provide a requested result. Can be used in constant expressions
+   * \tparam RT The type representing the requested result.
+   * \return boolean indicating if a requested result can be provided
+   */
   template <typename RT>
   static constexpr bool canProvideResultType() {
     return static_cast<bool>(std::is_same_v<RT, ResultType::linearStress>);

--- a/ikarus/finiteelements/mechanics/linearelastic.hh
+++ b/ikarus/finiteelements/mechanics/linearelastic.hh
@@ -210,28 +210,41 @@ public:
    * \param local Local position vector.
    * \return calculated result
    *
-   * \tparam resType The type representing the requested result.
+   * \tparam RT The type representing the requested result.
    */
-  template <ResultType resType>
+  template <typename  RT>
   auto calculateAt(const FERequirementType& req, const Dune::FieldVector<double, Traits::mydim>& local) const {
-    static_assert(resType == ResultType::linearStress, "The requested result type is NOT implemented.");
 
-    if constexpr (resType == ResultType::linearStress) {
+    if constexpr (std::is_same_v<RT,ResultType::linearStress> ) {
       const auto eps = strainFunction(req);
       const auto C   = materialTangent();
       auto epsVoigt  = eps.evaluate(local, Dune::on(Dune::DerivativeDirections::gridElement));
 
       return (C * epsVoigt).eval();
-    }
+    }else
+      static_assert(Dune::AlwaysFalse<RT>::value, "The requested result type is NOT implemented.");
+
   }
 
-  template <ResultType resultType>
+  template <typename RT>
   static constexpr bool canProvideResultType() {
-    if constexpr (resultType == ResultType::linearStress)
+    if constexpr (std::is_same_v<RT, ResultType::linearStress>)
       return true;
     else
       return false;
   }
+
+//   template<typename ... Args>
+//   struct giveType
+//   {  };
+//
+//   template<int worldDim, int gridDim, typename ScalarType>
+// struct giveType<ResultType::linearStress,worldDim,gridDim,ScalarType>
+//   {
+//     constexpr static int matrixSize = (-1 + ct_sqrt(1 + 8 * gridDim)) / 2;
+//     using type =  Eigen::Matrix<ScalarType, matrixSize, 1>;
+//     using voigtype =  Eigen::Matrix<ScalarType, matrixSize, 1>;
+//   };
 
 private:
   std::shared_ptr<const Geometry> geo_;

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -267,12 +267,20 @@ public:
       const auto H         = uFunction.evaluateDerivative(local, Dune::wrt(spatialAll), Dune::on(gridElement));
       const auto E         = (0.5 * (H.transpose() + H + H.transpose() * H)).eval();
 
-      return mat_.template stresses<StrainTags::greenLagrangian, voigt>(toVoigt(E));
+      if constexpr (voigt)
+        return mat_.template stresses<StrainTags::greenLagrangian>(toVoigt(E));
+      else
+        return fromVoigt(mat_.template stresses<StrainTags::greenLagrangian>(toVoigt(E)), false);
     } else
       static_assert(Dune::AlwaysFalse<RT>::value, "The requested result type is NOT implemented.");
     __builtin_unreachable();
   }
 
+  /**
+   * \brief Returns whether an element can provide a requested result. Can be used in constant expressions
+   * \tparam RT The type representing the requested result.
+   * \return boolean indicating if a requested result can be provided
+   */
   template <typename RT>
   static constexpr bool canProvideResultType() {
     return static_cast<bool>(std::is_same_v<RT, ResultType::PK2Stress>);

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -253,19 +253,20 @@ public:
    *
    * \tparam resType The type representing the requested result.
    */
-  template <ResultType resType>
+  template <typename  RT>
   auto calculateAt(const FERequirementType& req, const Dune::FieldVector<double, Traits::mydim>& local) const {
-    static_assert(resType == ResultType::PK2Stress, "The requested result type is NOT implemented.");
-
     using namespace Dune::DerivativeDirections;
-    if constexpr (resType == ResultType::PK2Stress) {
+
+    if constexpr (std::is_same_v<RT,ResultType::linearStress> ) {
       const auto uFunction = displacementFunction(req);
       const auto H         = uFunction.evaluateDerivative(local, Dune::wrt(spatialAll), Dune::on(gridElement));
       const auto E         = (0.5 * (H.transpose() + H + H.transpose() * H)).eval();
       const auto EVoigt    = toVoigt(E);
 
       return mat_.template stresses<StrainTags::greenLagrangian>(EVoigt);
-    }
+    } else
+      static_assert(Dune::AlwaysFalse<RT>::value, "The requested result type is NOT implemented.");
+
   }
 
 private:

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -253,11 +253,11 @@ public:
    *
    * \tparam resType The type representing the requested result.
    */
-  template <typename  RT>
+  template <typename RT>
   auto calculateAt(const FERequirementType& req, const Dune::FieldVector<double, Traits::mydim>& local) const {
     using namespace Dune::DerivativeDirections;
 
-    if constexpr (std::is_same_v<RT,ResultType::linearStress> ) {
+    if constexpr (std::is_same_v<RT, ResultType::linearStress>) {
       const auto uFunction = displacementFunction(req);
       const auto H         = uFunction.evaluateDerivative(local, Dune::wrt(spatialAll), Dune::on(gridElement));
       const auto E         = (0.5 * (H.transpose() + H + H.transpose() * H)).eval();
@@ -266,7 +266,6 @@ public:
       return mat_.template stresses<StrainTags::greenLagrangian>(EVoigt);
     } else
       static_assert(Dune::AlwaysFalse<RT>::value, "The requested result type is NOT implemented.");
-
   }
 
 private:

--- a/ikarus/finiteelements/mechanics/nonlinearelastic.hh
+++ b/ikarus/finiteelements/mechanics/nonlinearelastic.hh
@@ -64,6 +64,9 @@ public:
   static constexpr int myDim       = Traits::mydim;
   static constexpr auto strainType = StrainTags::greenLagrangian;
 
+  template <typename RT, bool voigt = true>
+  using ResultTypeType = resultType_t<RT, myDim, Traits::worlddim, voigt>;
+
   /**
    * \brief Constructor for the NonLinearElastic class.
    *
@@ -251,21 +254,28 @@ public:
    * \param local Local position vector.
    * \return calculated result
    *
-   * \tparam resType The type representing the requested result.
+   * \tparam RT The type representing the requested result.
+   * \tparam voigt Returns result in Voigt notation (if applicable)
    */
-  template <typename RT>
-  auto calculateAt(const FERequirementType& req, const Dune::FieldVector<double, Traits::mydim>& local) const {
+  template <typename RT, bool voigt = true>
+  auto calculateAt(const FERequirementType& req, const Dune::FieldVector<double, Traits::mydim>& local) const
+      -> ResultTypeType<RT, voigt> {
     using namespace Dune::DerivativeDirections;
 
-    if constexpr (std::is_same_v<RT, ResultType::linearStress>) {
+    if constexpr (std::is_same_v<RT, ResultType::PK2Stress>) {
       const auto uFunction = displacementFunction(req);
       const auto H         = uFunction.evaluateDerivative(local, Dune::wrt(spatialAll), Dune::on(gridElement));
       const auto E         = (0.5 * (H.transpose() + H + H.transpose() * H)).eval();
-      const auto EVoigt    = toVoigt(E);
 
-      return mat_.template stresses<StrainTags::greenLagrangian>(EVoigt);
+      return mat_.template stresses<StrainTags::greenLagrangian, voigt>(toVoigt(E));
     } else
       static_assert(Dune::AlwaysFalse<RT>::value, "The requested result type is NOT implemented.");
+    __builtin_unreachable();
+  }
+
+  template <typename RT>
+  static constexpr bool canProvideResultType() {
+    return static_cast<bool>(std::is_same_v<RT, ResultType::PK2Stress>);
   }
 
 private:

--- a/ikarus/io/resultevaluators.hh
+++ b/ikarus/io/resultevaluators.hh
@@ -34,15 +34,13 @@ struct VonMises
    * \return von Mises stress
    */
   double operator()(const auto& resultArray, [[maybe_unused]] const int comp) const {
-    if constexpr (dim == 2) {
-      const auto s_x  = resultArray(0, 0);
-      const auto s_y  = resultArray(1, 0);
-      const auto s_xy = resultArray(2, 0);
+    const auto s_x = resultArray(0, 0);
+    const auto s_y = resultArray(1, 0);
 
+    if constexpr (dim == 2) {
+      const auto s_xy = resultArray(2, 0);
       return std::sqrt(Dune::power(s_x, 2) + Dune::power(s_y, 2) - s_x * s_y + 3 * Dune::power(s_xy, 2));
     } else {
-      const auto s_x  = resultArray(0, 0);
-      const auto s_y  = resultArray(1, 0);
       const auto s_z  = resultArray(2, 0);
       const auto s_yz = resultArray(3, 0);
       const auto s_xz = resultArray(4, 0);

--- a/ikarus/io/resultfunction.hh
+++ b/ikarus/io/resultfunction.hh
@@ -97,10 +97,10 @@ public:
    * \return String representing the name of the result type
    */
   [[nodiscard]] constexpr std::string name() const override {
-    if constexpr (std::is_same_v<UserFunction, Impl::DefaultUserFunction>)
-      return toString(resType{});
-    else
+    if constexpr (requires { UserFunction::name(); })
       return userFunction_.name();
+    else
+      return toString(resType{});
   }
 
   /**

--- a/ikarus/io/resultfunction.hh
+++ b/ikarus/io/resultfunction.hh
@@ -45,7 +45,7 @@ namespace Impl {
  * \tparam UserFunction Type of the user-defined function for custom result evaluation (default is
 DefaultUserFunction)
  */
-template <typename FE, ResultType resType, typename UserFunction = Impl::DefaultUserFunction>
+template <typename FE, typename resType, typename UserFunction = Impl::DefaultUserFunction>
 class ResultFunction : public Dune::VTKFunction<typename FE::GridView>
 {
 public:
@@ -98,7 +98,7 @@ public:
    */
   [[nodiscard]] constexpr std::string name() const override {
     if constexpr (std::is_same_v<UserFunction, Impl::DefaultUserFunction>)
-      return toString(resType);
+      return toString(resType{});
     else
       return userFunction_.name();
   }
@@ -146,7 +146,7 @@ private:
  * \tparam resType requested result type
  * \tparam UserFunction Type of the user-defined function for custom result evaluation (default is DefaultUserFunction)
  */
-template <ResultType resType, typename UserFunction = Impl::DefaultUserFunction, typename FE>
+template <typename resType, typename UserFunction = Impl::DefaultUserFunction, typename FE>
 auto makeResultFunction(std::vector<FE>* fes, const typename FE::FERequirementType& req) {
   return std::make_shared<ResultFunction<FE, resType, UserFunction>>(fes, req);
 }
@@ -167,7 +167,7 @@ auto makeResultFunction(std::vector<FE>* fes, const typename FE::FERequirementTy
  * \tparam UserFunction Type of the user-defined function for custom result evaluation (default is
  * DefaultUserFunction)
  */
-template <ResultType resType, typename UserFunction = Impl::DefaultUserFunction, typename FE>
+template <typename resType, typename UserFunction = Impl::DefaultUserFunction, typename FE>
 auto makeResultVtkFunction(std::vector<FE>* fes, const typename FE::FERequirementType& req) {
   return Dune::Vtk::Function<typename FE::GridView>(
       std::make_shared<ResultFunction<FE, resType, UserFunction>>(fes, req));

--- a/ikarus/python/finiteelements/nonlinearelastic.hh
+++ b/ikarus/python/finiteelements/nonlinearelastic.hh
@@ -104,8 +104,8 @@ void registerNonLinearElastic(pybind11::handle scope, pybind11::class_<NonLinear
   cls.def(
       "calculateAt",
       [](NonLinearElastic& self, const FERequirements& req, const Dune::FieldVector<double, Traits::mydim>& local,
-         ResultType resType) {
-        if (resType == ResultType::PK2Stress)
+         std::string& resType) {
+        if (resType == "PK2Stress")
           return self.template calculateAt<ResultType::PK2Stress>(req, local);
         else
           DUNE_THROW(Dune::NotImplemented, "Nonlinear-elastic element only supports PK2 stress as result.");

--- a/ikarus/python/finiteelements/registerelement.hh
+++ b/ikarus/python/finiteelements/registerelement.hh
@@ -124,8 +124,8 @@ void registerElement(pybind11::handle scope, pybind11::class_<FE, options...> cl
   cls.def(
       "calculateAt",
       [](FE& self, const FERequirements& req, const Dune::FieldVector<double, Traits::mydim>& local,
-         ResultType resType) {
-        if (resType == ResultType::linearStress)
+         std::string& resType) {
+        if (resType == "linearStress")
           return self.template calculateAt<ResultType::linearStress>(req, local);
         else
           DUNE_THROW(Dune::NotImplemented, "Linear-lastic element only supports linearStress as result.");

--- a/ikarus/python/test/linearelastictest.py
+++ b/ikarus/python/test/linearelastictest.py
@@ -125,14 +125,10 @@ if __name__ == "__main__":
     indexSet = grid.indexSet
 
     stressFuncScalar = grid.function(
-        lambda e, x: fes[indexSet.index(e)].calculateAt(
-            req, x, iks.ResultType.linearStress
-        )[0]
+        lambda e, x: fes[indexSet.index(e)].calculateAt(req, x, "linearStress")[0]
     )
     stressFuncVec = grid.function(
-        lambda e, x: fes[indexSet.index(e)].calculateAt(
-            req, x, iks.ResultType.linearStress
-        )[:]
+        lambda e, x: fes[indexSet.index(e)].calculateAt(req, x, "linearStress")[:]
     )
     # Writing results into vtk file
     from utils import output_path
@@ -147,9 +143,9 @@ if __name__ == "__main__":
 
     writer2.write(name=output_path() + "result")
 
-    # Queriing for a different ResultType should result in a runtime error
+    # Querying for a different ResultType should result in a runtime error
     try:
-        fes[0].calculateAt(req, np.array([0.5, 0.5]), iks.ResultType.cauchyStress)
+        fes[0].calculateAt(req, np.array([0.5, 0.5]), "PK2Stress")
     except RuntimeError:
         assert True
     else:

--- a/ikarus/python/test/nonlinearelastictest.py
+++ b/ikarus/python/test/nonlinearelastictest.py
@@ -135,4 +135,4 @@ if __name__ == "__main__":
     fullD = assembler.createFullVector(resultd2.x)
     req.insertGlobalSolution(iks.FESolutions.displacement, fullD)
 
-    res1 = fes[0].calculateAt(req, np.array([0.5, 0.5]), iks.ResultType.PK2Stress)
+    res1 = fes[0].calculateAt(req, np.array([0.5, 0.5]), "PK2Stress")

--- a/ikarus/utils/functionhelper.hh
+++ b/ikarus/utils/functionhelper.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <ranges>
+
 namespace Ikarus::utils {
 /**
  * \brief A function to obtain the global positions of the nodes of an element with Lagrangian basis, see Dune book
@@ -36,6 +38,26 @@ void obtainLagrangeNodePositions(const LV& localView,
   }
   for (auto& nCoord : lagrangeNodeCoords)
     nCoord = localView.element().geometry().global(nCoord);
+}
+/**
+ * \brief A function to obtain the local coordinates of the vertices of an FiniteElement
+ * \ingroup utils
+ * \tparam FiniteElement Type of the finite element
+ * \param fe finite element
+ * \return std::vector of LocalCoordinates of the element
+ */
+template <typename FiniteElement>
+auto getVertexPositions(FiniteElement& fe) {
+  constexpr int dim            = FiniteElement::Traits::mydim;
+  const auto& element          = fe.gridElement();
+  const auto& referenceElement = Dune::referenceElement<double, dim>(element.type());
+  const int numberOfVertices   = referenceElement.size(dim);
+
+  std::vector<typename FiniteElement::GridElement::Geometry::LocalCoordinate> positions;
+  for (auto i : std::views::iota(0, numberOfVertices))
+    positions.push_back(referenceElement.position(i, dim));
+
+  return positions;
 }
 
 } // namespace Ikarus::utils

--- a/python/ikarus/_ikarus.cc
+++ b/python/ikarus/_ikarus.cc
@@ -69,19 +69,6 @@ PYBIND11_MODULE(_ikarus, m) {
   fePar.value("loadfactor", FEParameter::loadfactor);
   fePar.value("time", FEParameter::time);
 
-  py::enum_<ResultType> resType(m, "ResultType");
-  resType.value("noType", ResultType::noType);
-  resType.value("magnetization", ResultType::magnetization);
-  resType.value("gradientNormOfMagnetization", ResultType::gradientNormOfMagnetization);
-  resType.value("vectorPotential", ResultType::vectorPotential);
-  resType.value("divergenceOfVectorPotential", ResultType::divergenceOfVectorPotential);
-  resType.value("BField", ResultType::BField);
-  resType.value("HField", ResultType::HField);
-  resType.value("cauchyStress", ResultType::cauchyStress);
-  resType.value("PK2Stress", ResultType::PK2Stress);
-  resType.value("linearStress", ResultType::linearStress);
-  resType.value("director", ResultType::director);
-
   using VWd = ValueWrapper<double>;
   auto valueWrapperDouble =
       Dune::Python::insertClass<VWd>(m, "ValueWrapper", Dune::Python::GenerateTypeName("ValueWrapper<double>")).first;

--- a/tests/src/resultcollection.hh
+++ b/tests/src/resultcollection.hh
@@ -5,20 +5,7 @@
 #include "testcommon.hh"
 
 #include <ikarus/finiteelements/ferequirements.hh>
-
-template <typename FiniteElement>
-auto getVertexPositions(FiniteElement& fe) {
-  constexpr int dim            = FiniteElement::Traits::mydim;
-  const auto& element          = fe.gridElement();
-  const auto& referenceElement = Dune::referenceElement<double, dim>(element.type());
-  const int numberOfVertices   = referenceElement.size(dim);
-
-  std::vector<typename FiniteElement::GridElement::Geometry::LocalCoordinate> positions;
-  for (auto i : std::views::iota(0, numberOfVertices))
-    positions.push_back(referenceElement.position(i, dim));
-
-  return positions;
-}
+#include <ikarus/utils/functionhelper.hh>
 
 inline auto linearStressResultsOfSquare = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
   constexpr int vertices   = 4;
@@ -40,7 +27,7 @@ inline auto linearStressResultsOfSquare = []<typename NOP, typename FE>(NOP& non
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 inline auto linearVonMisesResultsOfSquare = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
@@ -55,7 +42,7 @@ inline auto linearVonMisesResultsOfSquare = []<typename NOP, typename FE>(NOP& n
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 inline auto linearPrincipalStressResultsOfSquare = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
@@ -75,7 +62,7 @@ inline auto linearPrincipalStressResultsOfSquare = []<typename NOP, typename FE>
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 inline auto linearStressResultsOfCube = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
@@ -99,7 +86,7 @@ inline auto linearStressResultsOfCube = []<typename NOP, typename FE>(NOP& nonLi
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 inline auto linearVonMisesResultsOfCube = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
@@ -115,7 +102,7 @@ inline auto linearVonMisesResultsOfCube = []<typename NOP, typename FE>(NOP& non
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 inline auto linearPrincipalStressResultsOfCube = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
@@ -139,7 +126,7 @@ inline auto linearPrincipalStressResultsOfCube = []<typename NOP, typename FE>(N
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 inline auto linearStressResultsOfTriangle = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
@@ -155,7 +142,7 @@ inline auto linearStressResultsOfTriangle = []<typename NOP, typename FE>(NOP& n
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 inline auto linearStressResultsOfTetrahedron = []<typename NOP, typename FE>(NOP& nonLinearOperator, FE& fe) {
@@ -172,7 +159,7 @@ inline auto linearStressResultsOfTetrahedron = []<typename NOP, typename FE>(NOP
   auto feRequirements =
       typename FE::FERequirementType().insertGlobalSolution(Ikarus::FESolutions::displacement, displacement);
 
-  return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
+  return std::make_tuple(feRequirements, expectedStress, Ikarus::utils::getVertexPositions(fe));
 };
 
 template <typename CompileTimeMatrix>
@@ -186,7 +173,6 @@ auto stressResultsToMatrix(const CompileTimeMatrix& expectedResults) {
   for (const auto i : std::views::iota(0, vertices)) {
     auto stressMatrix         = Ikarus::fromVoigt(Eigen::Vector<double, voigtComps>(expectedResults.row(i)), false);
     transformedResults.row(i) = Eigen::Map<Eigen::VectorXd>(stressMatrix.data(), comps);
-    ;
   }
   return transformedResults;
 }

--- a/tests/src/resultcollection.hh
+++ b/tests/src/resultcollection.hh
@@ -174,3 +174,19 @@ inline auto linearStressResultsOfTetrahedron = []<typename NOP, typename FE>(NOP
 
   return std::make_tuple(feRequirements, expectedStress, getVertexPositions(fe));
 };
+
+template <typename CompileTimeMatrix>
+auto stressResultsToMatrix(const CompileTimeMatrix& expectedResults) {
+  constexpr int vertices   = CompileTimeMatrix::CompileTimeTraits::RowsAtCompileTime;
+  constexpr int voigtComps = CompileTimeMatrix::CompileTimeTraits::ColsAtCompileTime;
+  constexpr int matrixSize = (-1 + Ikarus::ct_sqrt(1 + 8 * vertices)) / 2;
+  constexpr int comps      = matrixSize * matrixSize;
+
+  Eigen::Matrix<double, vertices, comps> transformedResults;
+  for (const auto i : std::views::iota(0, vertices)) {
+    auto stressMatrix         = Ikarus::fromVoigt(Eigen::Vector<double, voigtComps>(expectedResults.row(i)), false);
+    transformedResults.row(i) = Eigen::Map<Eigen::VectorXd>(stressMatrix.data(), comps);
+    ;
+  }
+  return transformedResults;
+}

--- a/tests/src/testcommon.hh
+++ b/tests/src/testcommon.hh
@@ -236,7 +236,7 @@ template <typename NonLinearOperator>
   return t;
 }
 
-template <Ikarus::ResultType resType>
+template <typename resType>
 [[nodiscard]] auto checkCalculateAt(auto& nonLinearOperator, auto& fe, const auto& feRequirements,
                                     const auto& expectedResult, const auto& evaluationPositions,
                                     const std::string& messageIfFailed = "") {
@@ -251,19 +251,19 @@ template <Ikarus::ResultType resType>
       computedResults.row(i++) = result.transpose();
     }
     const bool isResultCorrect = isApproxSame(computedResults, expectedResult, 1e-8);
-    t.check(isResultCorrect) << "Computed Result for " << toString(resType) << " is not the same as expected result:\n"
+    t.check(isResultCorrect) << "Computed Result for " << toString(resType{}) << " is not the same as expected result:\n"
                              << "It is:\n"
                              << computedResults << "\nBut should be:\n"
                              << expectedResult << "\n"
                              << messageIfFailed;
   }
   else
-    t.check(false) << "Element can not provide the requested RsultType " << toString(resType) << messageIfFailed;
+    t.check(false) << "Element can not provide the requested RsultType " << toString(resType{}) << messageIfFailed;
 
   return t;
 }
 
-template <Ikarus::ResultType resType, typename ResultEvaluator>
+template <typename resType, typename ResultEvaluator>
 [[nodiscard]] auto checkResultFunction(auto& nonLinearOperator, auto& fe, const auto& feRequirements,
                                        const auto& expectedResult, const auto& evaluationPositions,
                                        const std::string& messageIfFailed = "") {
@@ -287,7 +287,7 @@ template <Ikarus::ResultType resType, typename ResultEvaluator>
     ++i;
   }
   const bool isResultCorrect = isApproxSame(computedResults, expectedResult, 1e-8);
-  t.check(isResultCorrect) << "Computed Result for " << toString(resType) << " is not the same as expected result:\n"
+  t.check(isResultCorrect) << "Computed Result for " << toString(resType{}) << " is not the same as expected result:\n"
                            << "It is:\n"
                            << computedResults << "\nBut should be:\n"
                            << expectedResult << "\n"

--- a/tests/src/testenhancedassumedstrains.cpp
+++ b/tests/src/testenhancedassumedstrains.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv) {
   t.subTest(testFEElement<EASElement>(
       firstOrderLagrangePrePower2Basis, "EAS", unDistorted, Dune::ReferenceElements<double, 2>::cube(),
       checkCalculateAtFunctorFactory<Ikarus::ResultType::linearStress>(linearStressResultsOfSquare),
+      checkCalculateAtFunctorFactory<Ikarus::ResultType::linearStress, false>(linearStressResultsOfSquare),
       checkResultFunctionFunctorFactory<Ikarus::ResultType::linearStress>(linearStressResultsOfSquare)));
 
   return t.exit();

--- a/tests/src/testfeelement.hh
+++ b/tests/src/testfeelement.hh
@@ -128,7 +128,7 @@ inline auto checkJacobianFunctor = [](auto& nonLinOp, [[maybe_unused]] auto& fe,
   return checkJacobianOfElement(subOperator);
 };
 
-template <Ikarus::ResultType resType, typename ResultEvaluator = Ikarus::Impl::DefaultUserFunction>
+template <typename resType, typename ResultEvaluator = Ikarus::Impl::DefaultUserFunction>
 auto checkResultFunctionFunctorFactory(const auto& resultCollectionFunction) {
   return [&](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) {
     auto [feRequirements, expectedStress, positions] = resultCollectionFunction(nonLinOp, fe);
@@ -140,7 +140,7 @@ inline auto checkFEByAutoDiffFunctor = [](auto& nonLinOp, auto& fe, auto& req) {
   return checkFEByAutoDiff(nonLinOp, fe, req);
 };
 
-template <Ikarus::ResultType resType>
+template <typename resType>
 auto checkCalculateAtFunctorFactory(const auto& resultCollectionFunction) {
   return [&](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) {
     auto [feRequirements, expectedStress, positions] = resultCollectionFunction(nonLinOp, fe);

--- a/tests/src/testfeelement.hh
+++ b/tests/src/testfeelement.hh
@@ -140,10 +140,14 @@ inline auto checkFEByAutoDiffFunctor = [](auto& nonLinOp, auto& fe, auto& req) {
   return checkFEByAutoDiff(nonLinOp, fe, req);
 };
 
-template <typename resType>
+template <typename resType, bool voigt = true>
 auto checkCalculateAtFunctorFactory(const auto& resultCollectionFunction) {
   return [&](auto& nonLinOp, auto& fe, [[maybe_unused]] auto& req) {
     auto [feRequirements, expectedStress, positions] = resultCollectionFunction(nonLinOp, fe);
-    return checkCalculateAt<resType>(nonLinOp, fe, feRequirements, expectedStress, positions);
+    if constexpr (voigt)
+      return checkCalculateAt<resType>(nonLinOp, fe, feRequirements, expectedStress, positions);
+    else
+      return checkCalculateAt<resType, voigt>(nonLinOp, fe, feRequirements, stressResultsToMatrix(expectedStress),
+                                              positions);
   };
 }

--- a/tests/src/testlinearelasticity.cpp
+++ b/tests/src/testlinearelasticity.cpp
@@ -14,6 +14,7 @@
 #include <ikarus/finiteelements/mechanics/linearelastic.hh>
 #include <ikarus/io/resultevaluators.hh>
 #include <ikarus/utils/init.hh>
+#include <ikarus/finiteelements/feresulttypes.hh>
 
 using Dune::TestSuite;
 

--- a/tests/src/testlinearelasticity.cpp
+++ b/tests/src/testlinearelasticity.cpp
@@ -45,19 +45,12 @@ int main(int argc, char** argv) {
   t.subTest(testFEElement<LinearElasticElement>(
       firstOrderLagrangePrePower2Basis, "LinearElastic", unDistorted, Dune::ReferenceElements<double, 2>::cube(),
       checkCalculateAtFunctorFactory<Ikarus::ResultType::linearStress>(linearStressResultsOfSquare),
+      checkCalculateAtFunctorFactory<Ikarus::ResultType::linearStress, false>(linearStressResultsOfSquare),
       checkResultFunctionFunctorFactory<Ikarus::ResultType::linearStress>(linearStressResultsOfSquare),
       checkResultFunctionFunctorFactory<Ikarus::ResultType::linearStress, Ikarus::ResultEvaluators::VonMises<2>>(
           linearVonMisesResultsOfSquare),
       checkResultFunctionFunctorFactory<Ikarus::ResultType::linearStress, Ikarus::ResultEvaluators::PrincipalStress<2>>(
           linearPrincipalStressResultsOfSquare)));
-
-  // Test simplex 2D
-  t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower2Basis, "LinearElastic", randomlyDistorted,
-                                                Dune::ReferenceElements<double, 2>::simplex(), checkGradientFunctor,
-                                                checkHessianFunctor, checkJacobianFunctor, checkFEByAutoDiffFunctor));
-  t.subTest(testFEElement<LinearElasticElement>(secondOrderLagrangePrePower2Basis, "LinearElastic", randomlyDistorted,
-                                                Dune::ReferenceElements<double, 2>::simplex(), checkGradientFunctor,
-                                                checkHessianFunctor, checkJacobianFunctor, checkFEByAutoDiffFunctor));
 
   // Test simplex 2D
   t.subTest(testFEElement<LinearElasticElement>(firstOrderLagrangePrePower2Basis, "LinearElastic", randomlyDistorted,

--- a/tests/src/testlinearelasticity.cpp
+++ b/tests/src/testlinearelasticity.cpp
@@ -11,10 +11,10 @@
 #include <dune/functions/functionspacebases/lagrangebasis.hh>
 #include <dune/functions/functionspacebases/powerbasis.hh>
 
+#include <ikarus/finiteelements/feresulttypes.hh>
 #include <ikarus/finiteelements/mechanics/linearelastic.hh>
 #include <ikarus/io/resultevaluators.hh>
 #include <ikarus/utils/init.hh>
-#include <ikarus/finiteelements/feresulttypes.hh>
 
 using Dune::TestSuite;
 

--- a/tests/src/testnonlinearelasticity.hh
+++ b/tests/src/testnonlinearelasticity.hh
@@ -157,6 +157,14 @@ auto NonLinearElasticityLoadControlNRandTR(const Material& mat) {
                                                                   << maxDisp;
   }
 
+  auto result = fes.front().template calculateAt<ResultType::PK2Stress, true>(req, {0, 0});
+  static_assert(
+      std::is_same_v<decltype(result), typename ElementType::template ResultTypeType<ResultType::PK2Stress, true>>);
+
+  auto result2 = fes.front().template calculateAt<ResultType::PK2Stress, false>(req, {0, 0});
+  static_assert(
+      std::is_same_v<decltype(result2), typename ElementType::template ResultTypeType<ResultType::PK2Stress, false>>);
+
   Dune::Vtk::VtkWriter<GridView> vtkWriter2(gridView);
   auto resultFunction = makeResultFunction<ResultType::PK2Stress>(&fes, req);
 


### PR DESCRIPTION
- added type traits for results
- calcualteAt can now take a `voigt`  argument to determine weather a result should be returned in Voigt notation
- `constexpr` function for each element that returns a bool wether an element can provide a `ResultType`
