### PR TITLE
move autodiffhelper from utils to autodiff folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 - Refactor `enhancedassumedstrains.hh` ([#247](https://github.com/ikarus-project/ikarus/pull/247))
 - add factory functions to `ResultFunction` ([#251](https://github.com/ikarus-project/ikarus/pull/251))
 - Refactor `febases` to handle any type of basis ([#256](https://github.com/ikarus-project/ikarus/pull/256))
+- Move `autodiffhelper.hh` from `utils` to `autodiff` folder ([#259](https://github.com/ikarus-project/ikarus/pull/259))
 
 ## Release v0.4 (Ganymede)
 

--- a/ikarus/finiteelements/autodiff/CMakeLists.txt
+++ b/ikarus/finiteelements/autodiff/CMakeLists.txt
@@ -2,4 +2,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # install headers
-install(FILES autodifffe.hh DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/autodiff)
+install(FILES autodifffe.hh autodiffhelper.hh
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/autodiff
+)

--- a/ikarus/finiteelements/autodiff/autodiffhelper.hh
+++ b/ikarus/finiteelements/autodiff/autodiffhelper.hh
@@ -10,7 +10,7 @@
 #include <autodiff/forward/dual.hpp>
 #include <autodiff/forward/dual/eigen.hpp>
 
-namespace Ikarus::utils {
+namespace Ikarus {
 
 /**
  * \brief Computes the Hessian matrix for each parameter of a given function.
@@ -41,4 +41,4 @@ void hessianN(const Fun& f, const autodiff::Wrt<Vars...>& wrt, const autodiff::A
   for (int i = 0; i < U::RowsAtCompileTime; ++i)
     hessian(fEntry(i), wrt, at, u[i], g[i], h[i]);
 }
-} // namespace Ikarus::utils
+} // namespace Ikarus

--- a/ikarus/utils/CMakeLists.txt
+++ b/ikarus/utils/CMakeLists.txt
@@ -4,7 +4,6 @@
 # install headers
 install(
   FILES algorithms.hh
-        autodiffhelper.hh
         basis.hh
         concepts.hh
         defaultfunctions.hh

--- a/tests/src/testautodiffhelper.cpp
+++ b/tests/src/testautodiffhelper.cpp
@@ -7,7 +7,7 @@
 
 #include <dune/common/test/testsuite.hh>
 
-#include <ikarus/utils/autodiffhelper.hh>
+#include <ikarus/finiteelements/autodiff/autodiffhelper.hh>
 #include <ikarus/utils/init.hh>
 
 using Dune::TestSuite;
@@ -25,7 +25,7 @@ static auto hessianN() {
   Eigen::Vector2dual2nd u;
   std::array<Eigen::Vector<double, 3>, 2> g;
   std::array<Eigen::Matrix<double, 3, 3>, 2> h;
-  Ikarus::utils::hessianN(f<autodiff::dual2nd>, wrt(x), at(x), u, g, h);
+  Ikarus::hessianN(f<autodiff::dual2nd>, wrt(x), at(x), u, g, h);
 
   for (Eigen::Index i = 0; i < 2; ++i) {
     Eigen::Vector3d gExpected;


### PR DESCRIPTION
The `utils` folder has a lot of files used in common within Ikarus. After #256, `autodifffe.hh` has its own folder `autodiff`. Hence `autodiffhelper` is moved to this folder such that all related files are together and also thereby serving the purpose of cleaning up the `utils` folder.