### PR TITLE
Add an About Ikarus page in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       adds the function `create`, which accepts a *bound* assembler, where a non-linear operator can be constructed on the fly. For this to
       work, all non-linear solvers have to implement a method `createNonlinearSolver`, which accepts the settings of the class and a nonlinear
       operator. See, e.g., `NewtonRaphsonWithSubsidiaryFunction`.
-
     - Python:
         - Bindings for Enums can now be done conveniently with the `ENUM_BINDINGS` macro.
         - The finite element functions `calculateMatrix`, `calculateVector`, and `calculateScalar` now directly accept the affordances.
@@ -54,6 +53,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     - Furthermore, a helper function to get the global index of a Lagrange node at the given global position is added.
 - Rework the Python Interface for `DirichletValues` plus add support to easily fix boundary DOFs of `Subspacebasis` in C++ and Python ([#305](https://github.com/ikarus-project/ikarus/pull/305))
 - Add a truss element ([#302](https://github.com/ikarus-project/ikarus/pull/302))
+- Add an About Ikarus page in the documentation ([#291](https://github.com/ikarus-project/ikarus/pull/291))
 
 ## Release v0.4 (Ganymede)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - C++ recommendations: 05_cppReferences/cppRef.md
   - Literature: 99_Literature/99Literature.md
   - Gallery: gallery.md
+  - About: about.md
   - Blog:
       - 04_blog/index.md
 #      - 04_blog/posts/v0.3.md #remove comments here for local draft

--- a/docs/website/about.md
+++ b/docs/website/about.md
@@ -1,0 +1,82 @@
+# About
+
+## What is Ikarus?
+
+Ikarus is a project developed by the Institute for Structural Mechanics, University of Stuttgart.
+It strives to develop an easy-to-read and easy-to-use framework to perform finite element analysis.
+It acts as a front-end code that utilizes several modules from [DUNE](https://dune-project.org/)
+and has some other dependencies.
+<figure class="inline end" markdown>
+![Ikarus Logo](auxiliaryImages/BigLogo_transparent.png)
+</figure>
+Ikarus endeavors to not *reinvent the wheel*
+but to just provide a generic interface that makes use of the existing modules, resulting in a more expressive,
+modular library to solve partial differential equations.
+The main idea is to provide users with a platform to rapidly prototype their ideas,
+thereby enabling researchers across the world to quickly test their various theories.
+One of the major principles that we follow is *"take what you need,"*
+where the users can pick different functionalities as per their requirements to try out their own examples.
+We also provide certain [examples](02_examples/index.md#examples) that can help a user get familiar with Ikarus.
+Ikarus itself is written in C++, but it also comes with [Python bindings](https://pypi.org/project/pyikarus/),
+which can then aid in combining the functionalities of Ikarus with different Python packages.
+It uses C++ template (meta) programming to achieve a general and easy-to-extend library.
+The idea of interface segregation between a grid space and an ansatz space from DUNE is heavily exploited here.
+Some of the features that we provide are
+
+- Element library (linear elastic, nonlinear elastic, Kirchhoff-Love Shell, truss)
+- Material library (St. Venant-Kirchhoff, Neo-Hookean)
+- Nonlinear Solvers (Newton-Raphson Method, Trust region Method)
+- Assemblers for sparse and dense matrices
+- Control routines (load control, displacement control, arc-length control)
+- Handle Dirichlet boundary conditions
+- Observer patterns to log user-desired information as an output
+
+## Dependencies
+
+!!! bug
+    This section will be updated.
+
+## Ikarus Core Developers
+
+The Ikarus Core Developers develop, maintain and look after Ikarus.
+
+- [Alexander Müller](https://www.ibb.uni-stuttgart.de/en/institute/team/Mueller-00006/)
+- [Tarun Kumar Mitruka Vinod Kumar Mitruka](https://www.ibb.uni-stuttgart.de/en/institute/team/Vinod-Kumar-Mitruka/)
+- [Henrik Jakob](https://www.ibb.uni-stuttgart.de/en/institute/team/Jakob-00003/)
+
+## Talks
+
+- **Jakob, H.**, Vinod Kumar Mitruka, T. K. M., Müller, A.
+  *Ikarus and dune-iga: Easy-To-Use C++ Libraries With Python Bindings for Structural Analysis Within DUNE*.
+  9th European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS),
+  Lisbon, Portugal, June 03–07, 2024.
+- **Jakob, H.**, Vinod Kumar Mitruka, T. K. M., Müller, A.
+  *Ikarus and dune-iga: Easy-To-Use C++ Libraries With Python Bindings.*
+  FE im Schnee 2024,
+  Hirschegg, Austria, March 17–20, 2024.
+- **Müller, A.**, Jakob, H., Vinod Kumar Mitruka, T. K. M., Sander, O., Bischoff, M.
+  *Ikarus with dune-iga: An open-source C++ library for Isogeometric Analysis within the Dune framework.*
+  11th International Conference on Isogeometric Analysis 2023 (IGA 2023),
+  Lyon, France, June 18–21, 2023.
+
+## Datasets
+
+Different versions of Ikarus are released via the Data Repository of the University of Stuttgart ([DaRUS](https://darus.uni-stuttgart.de/)).
+
+- [Ikarus v0.4](https://doi.org/10.18419/darus-3889)
+- [Ikarus v0.3](https://doi.org/10.18419/darus-3303)
+
+## How to cite us?
+
+Here is the BibTex entry for our latest dataset:
+
+```text
+@data{Ikarusv04_2024,
+author    = {Müller, Alexander and Vinod Kumar Mitruka, Tarun Kumar Mitruka and Jakob, Henrik},
+publisher = {DaRUS},
+title     = {Ikarus v0.4},
+year      = {2024},
+version   = {V1},
+doi       = {10.18419/darus-3889}
+}
+```

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -13,6 +13,6 @@ The design of CI and the documentation were inspired by [Autodiff](https://autod
 The documentation is built using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
 
 Ikarus provides the tools to create one's own examples and rapidly prototype finite element solution algorithms.
-This is done by using template metaprogramming in C++ to write generic code, which is compiled for the example.
+This is done by using template metaprogramming in C++ to write generic code, which is compiled for the particular example.
 
 Look at our blog to see what we are currently working on: [Blog](04_blog)


### PR DESCRIPTION
This PR adds a very short About page, which described Ikarus briefly and also officially states the Ikarus Core Developers. Furthermore, it highlights the talks, datasets and citation data.
I decided to add a "About" page before the "Blog" because I found it more neater. There are missing dependencies that can be added after #141 is finished. Images can be added after we are converged to v1.0. Currently "About" is a separate page, but it can also be something that can be appended with the home page itself, but I thought may be this step can be done nicely after the gallery and cover photo(#122) is finished.

The CI would work after #289 is merged.