### PR TITLE
Add a truss element

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -88,5 +88,5 @@ jobs:
         uses: scheduleonce/lint-filenames@v2.0.0
         with:
           path: '{./ikarus/**,./python/**}'
-          pattern: '^[a-z0-9_\-]+(\.hh|\.cpp|\.inl|\.py|\.py\.in|\.cc|)$|CMakeLists\.txt'
+          pattern: '^[a-z0-9_\-]+(\.hh|\.cpp|\.inl|\.py|\.py\.in|\.cc|\.msh|)$|CMakeLists\.txt'
           # match all lowercase names with extensions .hh/.cpp/.inl/.py/.py.in/.cc and ignore CMakeLists.txt

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,6 +9,19 @@ Source: https://github.com/ikarus-project/ikarus
 # Copyright: $YEAR $NAME <$CONTACT>
 # License: ...
 
+Files: sandbox/src/*
+Copyright: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+License: CC0-1.0
+
+
+Files: ikarus/python/test/*
+Copyright: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+License: CC0-1.0
+
+Files: tests/src/testfiles/*
+Copyright: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+License: CC0-1.0
+
 Files: tests/src/testfiles/*
 Copyright: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
 License: CC0-1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     - This can be used, for instance, to apply concentrated forces or to add spring stiffness in a particular direction.
     - Furthermore, a helper function to get the global index of a Lagrange node at the given global position is added.
 - Rework the Python Interface for `DirichletValues` plus add support to easily fix boundary DOFs of `Subspacebasis` in C++ and Python ([#305](https://github.com/ikarus-project/ikarus/pull/305))
+- Add a truss element ([#302](https://github.com/ikarus-project/ikarus/pull/302))
 
 ## Release v0.4 (Ganymede)
 

--- a/ikarus/finiteelements/feresulttypes.hh
+++ b/ikarus/finiteelements/feresulttypes.hh
@@ -135,6 +135,8 @@ namespace ResultTypes {
   REGISTER_SIMPLE_RESULTTYPE(BField, worldDim, 1);
   REGISTER_SIMPLE_RESULTTYPE(HField, worldDim, 1);
 
+  REGISTER_SIMPLE_RESULTTYPE(axialForce, gridDim, gridDim);
+
   REGISTER_SIMPLE_RESULTTYPE(customType, Eigen::Dynamic, Eigen::Dynamic);
 } // namespace ResultTypes
 

--- a/ikarus/finiteelements/feresulttypes.hh
+++ b/ikarus/finiteelements/feresulttypes.hh
@@ -135,7 +135,9 @@ namespace ResultTypes {
   REGISTER_SIMPLE_RESULTTYPE(BField, worldDim, 1);
   REGISTER_SIMPLE_RESULTTYPE(HField, worldDim, 1);
 
-  REGISTER_SIMPLE_RESULTTYPE(axialForce, gridDim, gridDim);
+  REGISTER_SIMPLE_RESULTTYPE(cauchyAxialForce, 1, 1);
+  REGISTER_SIMPLE_RESULTTYPE(PK2AxialForce, 1, 1);
+  REGISTER_SIMPLE_RESULTTYPE(linearAxialForce, 1, 1);
 
   REGISTER_SIMPLE_RESULTTYPE(customType, Eigen::Dynamic, Eigen::Dynamic);
 } // namespace ResultTypes

--- a/ikarus/finiteelements/mechanics/CMakeLists.txt
+++ b/ikarus/finiteelements/mechanics/CMakeLists.txt
@@ -13,5 +13,6 @@ install(
         membranestrains.hh
         loads.hh
         easvariants.hh
+        truss.hh
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/finiteelements/mechanics
 )

--- a/ikarus/finiteelements/mechanics/truss.hh
+++ b/ikarus/finiteelements/mechanics/truss.hh
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+/**
+ * \file truss.hh
+ * \brief Definition of the Truss class for finite element mechanics computations.
+ * \ingroup  mechanics
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <dune/localfefunctions/eigenDuneTransformations.hh>
+
+#include <ikarus/finiteelements/fehelper.hh>
+#include <ikarus/finiteelements/ferequirements.hh>
+
+namespace Ikarus {
+
+template <typename PreFE, typename FE>
+class Truss;
+
+/**
+ * \brief A PreFE struct for truss elements.
+ */
+struct TrussPre
+{
+  double E; // Young's modulus
+  double A; // Cross-section area
+
+  template <typename PreFE, typename FE>
+  using Skill = Truss<PreFE, FE>;
+};
+
+/**
+ * \brief Truss class represents a truss finite element.
+ *
+ * \ingroup mechanics
+ *
+ * \tparam PreFE The type of the  pre finite element.
+ * \tparam FE The type of the finite element.
+ */
+template <typename PreFE, typename FE>
+class Truss
+{
+public:
+  using Traits       = PreFE::Traits;
+  using BasisHandler = typename Traits::BasisHandler;
+  using FlatBasis    = typename Traits::FlatBasis;
+  using Requirement =
+      FERequirementsFactory<FESolutions::displacement, FEParameter::loadfactor, Traits::useEigenRef>::type;
+  using LocalView = typename Traits::LocalView;
+  using Geometry  = typename Traits::Geometry;
+  using GridView  = typename Traits::GridView;
+  using Element   = typename Traits::Element;
+  using Pre       = TrussPre;
+
+  static constexpr int myDim    = Traits::mydim;
+  static constexpr int worldDim = Traits::worlddim;
+  static_assert(myDim == 1, "Truss elements should have myDim == 1");
+
+  /**
+   * \brief A structure representing kinematic variables.
+   *
+   * It includes Green-Lagrange strain, its first and second derivatives w.r.t displacements and
+   * the length of the undeformed and deformed geometry.
+   *
+   * \tparam ST The scalar type for the matrix and vector elements.
+   */
+  template <typename ST>
+  struct KinematicVariables
+  {
+    double L;                  ///< Length of the reference geometry
+    ST l;                      ///< Length of the deformed geometry
+    ST Egl;                    ///< Green-Lagrange strain
+    Eigen::VectorX<ST> dEdu;   ///< first derivative of Egl w.r.t displacements
+    Eigen::MatrixX<ST> ddEddu; ///< second derivative of Egl w.r.t displacements
+  };
+
+  /**
+   * \brief Constructor for the Truss class.
+   * \param pre The pre fe
+   */
+  explicit Truss(const Pre& pre)
+      : E{pre.E},
+        A{pre.A} {}
+
+  /**
+   * \brief Gets the displacement for the given Requirement and optional displacement vector.
+   *
+   * \tparam ST The scalar type for the displacement vector.
+   * \param par The Requirement object.
+   * \param dx Optional displacement vector.
+   * \return The local displacement vector of the type Dune::BlockVector<Dune::RealTuple<ST, worldDim>>
+   */
+  template <typename ST = double>
+  auto displacement(const Requirement& par,
+                    const std::optional<std::reference_wrapper<const Eigen::VectorX<ST>>>& dx = std::nullopt) const {
+    const auto& d = par.globalSolution();
+    auto disp     = Ikarus::FEHelper::localSolutionBlockVector<Traits>(d, underlying().localView(), dx);
+    return disp;
+  }
+
+  /**
+   * \brief Gets the strain for the given Requirement and optional displacement vector.
+   *
+   * \tparam ST The scalar type for the strain.
+   * \param par The Requirement object.
+   * \param dx Optional displacement vector.
+   * \return A tuple containing Green-Lagrange strain, its first and second derivatives w.r.t displacements and
+   * the length of the undeformed and deformed geometry.
+   */
+  template <class ST = double>
+  KinematicVariables<ST> computeStrain(
+      const Requirement& par,
+      const std::optional<std::reference_wrapper<const Eigen::VectorX<ST>>>& dx = std::nullopt) const {
+    KinematicVariables<ST> kin;
+    const auto& localView    = underlying().localView();
+    const auto& tree         = localView.tree();
+    const auto numberOfNodes = tree.child(0).finiteElement().size();
+    auto& ele                = localView.element();
+    const auto X1            = Dune::toEigen(ele.geometry().corner(0));
+    const auto X2            = Dune::toEigen(ele.geometry().corner(1));
+    const auto u             = Dune::viewAsEigenMatrixAsDynFixed(displacement(par, dx)).transpose().eval();
+    const auto A1            = X2 - X1;
+    const auto ud1           = u.col(1) - u.col(0);
+
+    const Eigen::Vector<ST, worldDim> x1 = X1 + u.col(0);
+    const Eigen::Vector<ST, worldDim> x2 = X2 + u.col(1);
+
+    const double Lsquared = A1.squaredNorm();
+    const ST lsquared     = (x2 - x1).squaredNorm();
+
+    kin.L = sqrt(Lsquared);
+    kin.l = sqrt(lsquared);
+
+    // Green-Lagrange strains
+    kin.Egl = 0.5 * (lsquared - Lsquared) / Lsquared;
+
+    // First derivative of Egl w.r.t displacements
+    kin.dEdu.setZero(worldDim * numberOfNodes);
+    kin.dEdu << -A1 - ud1, A1 + ud1;
+    kin.dEdu /= Lsquared;
+
+    // Second derivative of Egl w.r.t displacements
+    kin.ddEddu.setIdentity(worldDim * numberOfNodes, worldDim * numberOfNodes);
+    kin.ddEddu.template topRightCorner<worldDim, worldDim>()   = -Eigen::Matrix<ST, worldDim, worldDim>::Identity();
+    kin.ddEddu.template bottomLeftCorner<worldDim, worldDim>() = -Eigen::Matrix<ST, worldDim, worldDim>::Identity();
+    kin.ddEddu /= Lsquared;
+
+    return kin;
+  }
+
+  using SupportedResultTypes = std::tuple<decltype(makeRT<ResultTypes::axialForce>())>;
+
+private:
+  template <template <typename, int, int> class RT>
+  static consteval bool canProvideResultType() {
+    return isSameResultType<RT, ResultTypes::axialForce>;
+  }
+
+public:
+  /**
+   * \brief Calculates a requested result at a specific local position.
+   *
+   * \param req The Requirement object holding the global solution.
+   * \param local Local position vector.
+   * \tparam RT The requested result type
+   * \return calculated result
+   *
+   * \tparam RT The type representing the requested result.
+   */
+  template <template <typename, int, int> class RT>
+  requires(canProvideResultType<RT>())
+  auto calculateAtImpl(const Requirement& req, [[maybe_unused]] const Dune::FieldVector<double, Traits::mydim>& local,
+                       Dune::PriorityTag<0>) const {
+    using RTWrapper = ResultWrapper<RT<double, myDim, myDim>, ResultShape::Vector>;
+    if constexpr (isSameResultType<RT, ResultTypes::axialForce>) {
+      const auto [L, l, Egl, dEdu, ddEddu] = computeStrain(req);
+      auto N = Eigen::Vector<double, 1>{E * A * Egl * l / L}; // Axial force in deformed configuration
+      return RTWrapper{N};
+    }
+  }
+
+private:
+  //> CRTP
+  const auto& underlying() const { return static_cast<const FE&>(*this); }
+  auto& underlying() { return static_cast<FE&>(*this); }
+
+  double E;
+  double A;
+
+protected:
+  template <typename ScalarType>
+  void calculateMatrixImpl(
+      const Requirement& par, const MatrixAffordance& affordance, typename Traits::template MatrixType<> K,
+      const std::optional<std::reference_wrapper<const Eigen::VectorX<ScalarType>>>& dx = std::nullopt) const {
+    const auto [L, l, Egl, dEdu, ddEddu] = computeStrain(par, dx);
+    K += E * A * L * (dEdu * dEdu.transpose() + ddEddu * Egl);
+  }
+
+  template <typename ScalarType>
+  auto calculateScalarImpl(const Requirement& par, ScalarAffordance affordance,
+                           const std::optional<std::reference_wrapper<const Eigen::VectorX<ScalarType>>>& dx =
+                               std::nullopt) const -> ScalarType {
+    const auto [L, l, Egl, dEdu, ddEddu] = computeStrain(par, dx);
+    return 0.5 * E * A * L * Egl * Egl;
+  }
+
+  template <typename ScalarType>
+  void calculateVectorImpl(
+      const Requirement& par, VectorAffordance affordance, typename Traits::template VectorType<ScalarType> force,
+      const std::optional<std::reference_wrapper<const Eigen::VectorX<ScalarType>>>& dx = std::nullopt) const {
+    const auto [L, l, Egl, dEdu, ddEddu] = computeStrain(par, dx);
+    force += E * A * Egl * L * dEdu;
+  }
+};
+
+/**
+ * \brief A helper function to create a truss pre finite element.
+ * \param E Young's modulus of the truss member
+ * \param A Cross section area of the truss member
+ * \return A truss pre finite element.
+ */
+inline auto truss(const double E, const double A) {
+  TrussPre pre(E, A);
+
+  return pre;
+}
+} // namespace Ikarus

--- a/ikarus/python/finiteelements/registerpreelement.hh
+++ b/ikarus/python/finiteelements/registerpreelement.hh
@@ -37,6 +37,20 @@ void registerLinearElasticPre(pybind11::handle scope, pybind11::class_<LinearEla
 }
 
 /**
+ * @brief Registers a TrussPre class in Python.
+ *
+ * @tparam TrussPre The TrussPre class.
+ * @tparam options Additional options for the pybind11 class.
+ *
+ * @param scope Python handle to the module or class scope.
+ * @param cls The pybind11 class to register.
+ */
+template <class TrussPre, class... options>
+void registerTrussPre(pybind11::handle scope, pybind11::class_<TrussPre, options...> cls) {
+  cls.def(pybind11::init([](double emod, double area) { return new TrussPre({emod, area}); }));
+}
+
+/**
  * @brief Registers a KirchhoffLoveShellPre class in Python.
  *
  * @tparam KirchhoffLoveShellPre The KirchhoffLoveShellPre class.

--- a/ikarus/python/test/CMakeLists.txt
+++ b/ikarus/python/test/CMakeLists.txt
@@ -14,6 +14,17 @@ dune_python_add_test(
 
 dune_python_add_test(
   NAME
+  pytrussTest
+  SCRIPT
+  trusstest.py
+  WORKING_DIRECTORY
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  LABELS
+  python
+)
+
+dune_python_add_test(
+  NAME
   pynonLinearElasticTest
   SCRIPT
   nonlinearelastictest.py

--- a/ikarus/python/test/auxiliaryfiles/truss2d.msh
+++ b/ikarus/python/test/auxiliaryfiles/truss2d.msh
@@ -1,0 +1,17 @@
+$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+3
+1 0 0 0
+2 10 1 0
+3 20 0 0
+$EndNodes
+$Elements
+5
+1 15 2 0 1 1
+2 15 2 0 2 2
+3 15 2 0 3 3
+4 1 2 0 1 1 2
+5 1 2 0 2 2 3
+$EndElements

--- a/ikarus/python/test/auxiliaryfiles/truss3d.msh
+++ b/ikarus/python/test/auxiliaryfiles/truss3d.msh
@@ -1,0 +1,17 @@
+$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+3
+1 0 0 0
+2 2 1 4
+3 4 0 1
+$EndNodes
+$Elements
+5
+1 15 2 0 1 1
+2 15 2 0 2 2
+3 15 2 0 3 3
+4 1 2 0 1 1 2
+5 1 2 0 2 2 3
+$EndElements

--- a/ikarus/python/test/trusstest.py
+++ b/ikarus/python/test/trusstest.py
@@ -20,8 +20,8 @@ import dune.functions
 def trussTest(worldDim):
     assert worldDim == 2 or worldDim == 3
     gridDim = 1
-    dir = os.path.dirname(__file__)
-    filename = os.path.join(dir, f"auxiliaryfiles/truss{worldDim}d.msh")
+    filedir = os.path.dirname(__file__)
+    filename = os.path.join(filedir, f"auxiliaryfiles/truss{worldDim}d.msh")
     reader = (dune.grid.reader.gmsh, filename)
 
     grid = dune.foamgrid.foamGrid(reader, gridDim, worldDim)

--- a/ikarus/python/test/trusstest.py
+++ b/ikarus/python/test/trusstest.py
@@ -19,7 +19,7 @@ import dune.functions
 def trussTest(worldDim):
     assert worldDim == 2 or worldDim == 3
     gridDim = 1
-    filename = r'../pytests/auxiliaryfiles/truss' + str(worldDim) + 'd.msh'
+    filename = f"auxiliaryfiles/truss{worldDim}d.msh"
     reader = (dune.grid.reader.gmsh, filename)
 
     grid = dune.foamgrid.foamGrid(reader, gridDim, worldDim)
@@ -31,7 +31,7 @@ def trussTest(worldDim):
     flatBasis = basisLagrange1.flat()
     d = np.zeros(len(flatBasis))
 
-    lambdaLoad = iks.ValueWrapper(0.0)
+    lambdaLoad = iks.Scalar(0.0)
 
     fes = []
 

--- a/ikarus/python/test/trusstest.py
+++ b/ikarus/python/test/trusstest.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+
+import debug_info
+
+debug_info.setDebugFlags()
+
+import ikarus as iks
+from ikarus import finite_elements, assembler
+import numpy as np
+import scipy as sp
+
+import dune.foamgrid
+import dune.grid
+import dune.functions
+
+
+def trussTest(worldDim):
+    assert worldDim == 2 or worldDim == 3
+    gridDim = 1
+    filename = r'../pytests/auxiliaryfiles/truss' + str(worldDim) + 'd.msh'
+    reader = (dune.grid.reader.gmsh, filename)
+
+    grid = dune.foamgrid.foamGrid(reader, gridDim, worldDim)
+
+    basisLagrange1 = iks.basis(
+        grid, dune.functions.Power(dune.functions.Lagrange(order=1), worldDim)
+    )
+
+    flatBasis = basisLagrange1.flat()
+    d = np.zeros(len(flatBasis))
+
+    lambdaLoad = iks.ValueWrapper(0.0)
+
+    fes = []
+
+    tol = 1e-12
+
+    if worldDim == 2:
+        E = 30000
+        A = 0.1
+    else:
+        E = 2000
+        A = 1000
+
+    trusses = finite_elements.truss(youngs_modulus=E, cross_section=A)
+
+    for e in grid.elements:
+        fes.append(finite_elements.makeFE(basisLagrange1, trusses))
+        fes[-1].bind(e)
+
+    req = fes[0].createRequirement()
+    req.insertParameter(lambdaLoad)
+
+    assert req.parameter() == lambdaLoad
+    req.insertGlobalSolution(d)
+
+    d2 = req.globalSolution()
+
+    # check that is really the same data address
+    assert ("{}".format(hex(d2.__array_interface__["data"][0]))) == (
+        "{}".format(hex(d.__array_interface__["data"][0]))
+    )
+    assert len(d2) == len(d)
+    assert (d2 == d).all()
+
+    forces = np.zeros(worldDim * 2)
+    stiffness1 = np.zeros((worldDim * 2, worldDim * 2))
+    stiffness2 = np.zeros((worldDim * 2, worldDim * 2))
+    fes[0].calculateVector(req, iks.VectorAffordance.forces, forces)
+    fes[0].calculateMatrix(req, iks.MatrixAffordance.stiffness, stiffness1)
+    fes[1].calculateMatrix(req, iks.MatrixAffordance.stiffness, stiffness2)
+
+    dirichletValues = iks.dirichletValues(flatBasis)
+
+    def fixAllIndices(dirichletFlags, globalIndex):
+        dirichletFlags[globalIndex] = True
+
+    dirichletValues.fixBoundaryDOFs(fixAllIndices)
+    if worldDim == 3:
+        dirichletValues.setSingleDOF(1, True)
+
+    denseAssembler = assembler.denseFlatAssembler(fes, dirichletValues)
+    denseAssembler.bind(req, iks.AffordanceCollection.elastoStatics, iks.DBCOption.Full)
+
+    Kdense = denseAssembler.matrix()
+    forces = denseAssembler.vector()
+    forces[4] += 1.0
+
+    x = sp.linalg.solve(Kdense, -forces)
+
+    if worldDim == 2:
+        expectedDisp = (
+            -0.169172906288868320
+        )  # maximum vertical displacement of the center node
+        expectedAxialForce = np.array([-4.592837713552849940, -4.592837713552849940])
+    if worldDim == 3:
+        expectedDisp = (
+            -0.0008521190304919996
+        )  # maximum vertical displacement of the center node
+        expectedAxialForce = np.array([13.785353834067782586, -14.910220788494811472])
+
+    assert (
+        abs(abs(expectedDisp) - max(abs(x))) < tol
+    ), f"The expected displacement should be {expectedDisp} but is {max(abs(x))}"
+
+    req.insertGlobalSolution(x)
+
+    # Test calculateAt Function
+    N0 = fes[0].calculateAt(req, np.array([0.5]), "axialForce")[0]
+    N1 = fes[1].calculateAt(req, np.array([0.5]), "axialForce")[0]
+    N = np.array([N0, N1])
+
+    for i in range(2):
+        assert (
+            abs(expectedAxialForce[i] - N[i]) < tol
+        ), f"The expected axial force for element {i} is {expectedAxialForce[i]} but is {N[i]}"
+
+    # Querying for a different ResultType should result in a runtime error
+    try:
+        fes[0].calculateAt(req, np.array([0.5]), "PK2Stress")
+    except RuntimeError:
+        assert True
+    else:
+        assert False
+
+
+if __name__ == "__main__":
+    trussTest(2)
+    trussTest(3)

--- a/ikarus/utils/nonlinearoperator.hh
+++ b/ikarus/utils/nonlinearoperator.hh
@@ -353,7 +353,6 @@ public:
   auto subOperator() {
     auto derivatives = derivatives_;
     auto fs = functions([&derivatives]() -> decltype(auto) { return std::get<Derivatives>(derivatives); }()...);
-    std::cout << Dune::className(std::get<0>(fs.args)) << std::endl;
     Ikarus::NonLinearOperator<Impl::Functions<std::tuple_element_t<Derivatives, decltype(derivatives_)>...>,
                               Impl::Parameter<ParameterArgs...>>
         subOp(std::move(fs), Impl::applyAndRemoveReferenceWrapper(parameter<ParameterArgs...>, args_));

--- a/python/ikarus/finite_elements/__init__.py
+++ b/python/ikarus/finite_elements/__init__.py
@@ -117,6 +117,19 @@ def linearElastic(youngs_modulus, nu):
     element_type = "Ikarus::LinearElasticPre"
     return registerPreElement("LinearElasticPre", includes, element_type, youngs_modulus, nu)
 
+def truss(youngs_modulus, cross_section):
+    """
+    @brief Creates a truss pre-element.
+
+    @param youngs_modulus: Young's modulus.
+    @param cross_section: Cross-section area.
+
+    @return: The registered truss pre-element function.
+    """
+    includes = ["ikarus/finiteelements/mechanics/truss.hh"]
+    element_type = "Ikarus::TrussPre"
+    return registerPreElement("TrussPre", includes, element_type, youngs_modulus, cross_section)
+
 def eas(numberofparameters):
     """
     @brief Creates an enhanced assumed strains pre-element.

--- a/sandbox/src/auxiliaryFiles/circle.msh
+++ b/sandbox/src/auxiliaryFiles/circle.msh
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
-//
-// SPDX-License-Identifier: CC0-1.0
-
 $MeshFormat
 2.2 0 8
 $EndMeshFormat

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(programSourceFiles
     testshellthicknessquadrule.cpp
     testtrustregion.cpp
     testresultfunction.cpp
+    testtruss.cpp
 )
 
 set(TEST_DEPENDING_ON_LOCALFEFUNCTIONS

--- a/tests/src/checkfebyautodiff.hh
+++ b/tests/src/checkfebyautodiff.hh
@@ -56,14 +56,16 @@ auto checkFESByAutoDiff(const GridView& gridView, const PreBasis& pb, Skills&& s
             "automatic differentiation for " +
                 feClassName)
         << "K is \n"
-        << K << "\n KAutoDiff is \n"
-        << KAutoDiff << "The difference is " << (K - KAutoDiff);
+        << K << "\nKAutoDiff is \n"
+        << KAutoDiff << "\nThe difference is\n"
+        << (K - KAutoDiff);
 
     t.check(R.isApprox(RAutoDiff, tol),
             "Mismatch between the residual vectors obtained from explicit implementation and the one based on "
             "automatic differentiation for " +
                 feClassName)
-        << "The difference is " << (R - RAutoDiff);
+        << "R is " << R.transpose() << "\nRAutoDiff is " << RAutoDiff.transpose() << "\nThe difference is "
+        << (R - RAutoDiff).transpose();
 
     t.check(Dune::FloatCmp::eq(calculateScalar(fe, req, affordance.scalarAffordance()),
                                calculateScalar(feAutoDiff, req, affordance.scalarAffordance()), tol),

--- a/tests/src/testcommon.hh
+++ b/tests/src/testcommon.hh
@@ -8,6 +8,7 @@
 #include <dune/alugrid/grid.hh>
 #include <dune/common/test/testsuite.hh>
 #include <dune/common/typetraits.hh>
+#include <dune/foamgrid/foamgrid.hh>
 #include <dune/fufem/boundarypatch.hh>
 #include <dune/functions/functionspacebases/lagrangedgbasis.hh>
 #include <dune/grid/io/file/vtk.hh>
@@ -42,6 +43,12 @@ struct IgaSurfaceIn2D
 {
 };
 struct IgaSurfaceIn3D
+{
+};
+struct OneDFoamGridIn2D
+{
+};
+struct OneDFoamGridIn3D
 {
 };
 } // namespace Grids
@@ -121,7 +128,28 @@ auto createGrid([[maybe_unused]] int elex = 10, [[maybe_unused]] int eley = 10) 
     grid->globalRefine(1);
     return grid;
 #endif
-  }
+  } else if constexpr (std::is_same_v<GridType, Grids::OneDFoamGridIn2D>) {
+    Dune::GridFactory<Dune::FoamGrid<1, 2, double>> gridFactory;
+    constexpr double h = 1.0;
+    constexpr double L = 10.0;
+    gridFactory.insertVertex({0, 0});
+    gridFactory.insertVertex({L, h});
+    gridFactory.insertVertex({2 * L, 0});
+    gridFactory.insertElement(Dune::GeometryTypes::line, {0, 1});
+    gridFactory.insertElement(Dune::GeometryTypes::line, {1, 2});
+    auto grid = gridFactory.createGrid();
+    return grid;
+  } else if constexpr (std::is_same_v<GridType, Grids::OneDFoamGridIn3D>) {
+    Dune::GridFactory<Dune::FoamGrid<1, 3, double>> gridFactory;
+    gridFactory.insertVertex({0, 0, 0});
+    gridFactory.insertVertex({2, 1, 4});
+    gridFactory.insertVertex({4, 0, 1});
+    gridFactory.insertElement(Dune::GeometryTypes::line, {0, 1});
+    gridFactory.insertElement(Dune::GeometryTypes::line, {1, 2});
+    auto grid = gridFactory.createGrid();
+    return grid;
+  } else
+    DUNE_THROW(Dune::NotImplemented, "The requested GridType is not implemented.");
 }
 
 template <int size>

--- a/tests/src/testhelpers.hh
+++ b/tests/src/testhelpers.hh
@@ -34,7 +34,7 @@ requires std::is_integral_v<ScalarType>
 void checkScalars(TestSuiteType& t, const ScalarType val, const ScalarType expectedVal,
                   const std::string& messageIfFailed = "") {
   if constexpr (std::is_integral_v<ScalarType>)
-    t.check(val == expectedVal) << std::setprecision(16) << "Incorrect Scalar: Expected:\t" << expectedVal
+    t.check(val == expectedVal) << std::setprecision(16) << "Incorrect Scalar. Expected:\t" << expectedVal
                                 << " Actual:\t" << val << messageIfFailed;
 }
 
@@ -44,7 +44,7 @@ void checkScalars(TestSuiteType& t, const ScalarType val, const ScalarType expec
                   const std::string& messageIfFailed = "",
                   double tol                         = Dune::FloatCmp::DefaultEpsilon<ScalarType>::value()) {
   t.check(Dune::FloatCmp::eq(val, expectedVal, tol))
-      << std::setprecision(16) << "Incorrect Scalar: Expected:\t" << expectedVal << " Actual:\t" << val
+      << std::setprecision(16) << "Incorrect Scalar. Expected:\t" << expectedVal << " Actual:\t" << val
       << ". The used tolerance was " << tol << messageIfFailed;
 }
 

--- a/tests/src/testhelpers.hh
+++ b/tests/src/testhelpers.hh
@@ -34,8 +34,8 @@ requires std::is_integral_v<ScalarType>
 void checkScalars(TestSuiteType& t, const ScalarType val, const ScalarType expectedVal,
                   const std::string& messageIfFailed = "") {
   if constexpr (std::is_integral_v<ScalarType>)
-    t.check(val == expectedVal) << std::setprecision(16) << "Incorrect Scalar integer:\t" << expectedVal << " Actual:\t"
-                                << val << messageIfFailed;
+    t.check(val == expectedVal) << std::setprecision(16) << "Incorrect Scalar: Expected:\t" << expectedVal
+                                << " Actual:\t" << val << messageIfFailed;
 }
 
 template <typename TestSuiteType, typename ScalarType>
@@ -44,7 +44,7 @@ void checkScalars(TestSuiteType& t, const ScalarType val, const ScalarType expec
                   const std::string& messageIfFailed = "",
                   double tol                         = Dune::FloatCmp::DefaultEpsilon<ScalarType>::value()) {
   t.check(Dune::FloatCmp::eq(val, expectedVal, tol))
-      << std::setprecision(16) << "Incorrect Scalar floating point:\t" << expectedVal << " Actual:\t" << val
+      << std::setprecision(16) << "Incorrect Scalar: Expected:\t" << expectedVal << " Actual:\t" << val
       << ". The used tolerance was " << tol << messageIfFailed;
 }
 

--- a/tests/src/testtruss.cpp
+++ b/tests/src/testtruss.cpp
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <config.h>
+
+#include "checkfebyautodiff.hh"
+#include "testcommon.hh"
+#include "testhelpers.hh"
+
+#include <dune/functions/functionspacebases/lagrangebasis.hh>
+#include <dune/functions/functionspacebases/powerbasis.hh>
+#include <dune/grid/io/file/vtk/vtkwriter.hh>
+
+#include <Eigen/Core>
+
+#include <ikarus/assembler/assemblermanipulatorfuser.hh>
+#include <ikarus/assembler/simpleassemblers.hh>
+#include <ikarus/controlroutines/loadcontrol.hh>
+#include <ikarus/finiteelements/fefactory.hh>
+#include <ikarus/finiteelements/mechanics/truss.hh>
+#include <ikarus/solver/linearsolver/linearsolver.hh>
+#include <ikarus/solver/nonlinearsolver/newtonraphson.hh>
+#include <ikarus/solver/nonlinearsolver/nonlinearsolverfactory.hh>
+#include <ikarus/utils/basis.hh>
+#include <ikarus/utils/dirichletvalues.hh>
+#include <ikarus/utils/init.hh>
+#include <ikarus/utils/observer/controlvtkwriter.hh>
+#include <ikarus/utils/observer/genericobserver.hh>
+#include <ikarus/utils/observer/nonlinearsolverlogger.hh>
+
+using namespace Ikarus;
+using Dune::TestSuite;
+
+Eigen::Matrix<double, 4, 4> rotationMatrix2D(double theta) {
+  const auto c = std::cos(theta);
+  const auto s = std::sin(theta);
+  Eigen::Matrix2d rotMat;
+  rotMat.setZero();
+  rotMat << c, s, -s, c;
+  Eigen::Matrix<double, 4, 4> Q;
+  Q.setZero();
+  Q.block<2, 2>(0, 0) = rotMat;
+  Q.block<2, 2>(2, 2) = rotMat;
+  return Q;
+}
+
+static auto vonMisesTrussTest() {
+  TestSuite t("vonMisesTrussTest");
+  /// Construct grid
+  constexpr double h = 1.0;
+  constexpr double L = 10.0;
+  auto grid          = createGrid<Grids::OneDFoamGridIn2D>();
+  auto gridView      = grid->leafGridView();
+
+  /// Construct basis
+  using namespace Dune::Functions::BasisFactory;
+  auto basis = Ikarus::makeBasis(gridView, power<2>(lagrange<1>()));
+
+  /// Create finite elements
+  constexpr double E   = 30000;
+  constexpr double A   = 0.1;
+  constexpr double tol = 1e-10;
+  auto sk              = skills(truss(E, A));
+  using FEType         = decltype(makeFE(basis, sk));
+  std::vector<FEType> fes;
+  for (auto&& ge : elements(gridView)) {
+    fes.emplace_back(makeFE(basis, sk));
+    fes.back().bind(ge);
+  }
+
+  /// Collect dirichlet nodes
+  auto basisP = std::make_shared<const decltype(basis)>(basis);
+  DirichletValues dirichletValues(basisP->flat());
+  dirichletValues.fixBoundaryDOFs(
+      [&](auto& dirichletFlags, auto&& globalIndex) { dirichletFlags[globalIndex] = true; });
+  t.check(dirichletValues.fixedDOFsize() == 4, "Number of fixed DOFs is not equal to 4");
+
+  /// Create assembler
+  auto denseFlatAssembler = makeAssemblerManipulator(DenseFlatAssembler(fes, dirichletValues));
+
+  /// Create non-linear operator
+  double lambda = 0.0;
+  Eigen::VectorXd d;
+  d.setZero(basis.flat().size());
+
+  auto req = FEType::Requirement();
+  req.insertGlobalSolution(d).insertParameter(lambda);
+  denseFlatAssembler->bind(req, AffordanceCollections::elastoStatics, DBCOption::Full);
+
+  Dune::FieldVector<double, 2> pos{L, h};
+  // const auto globalIndices = utils::globalIndexFromGlobalPosition(basis.flat(), pos);
+  auto pointLoad = [&](const auto&, const auto&, auto, auto, Eigen::VectorXd& vec) -> void { vec[3] -= -lambda; };
+  denseFlatAssembler->bind(pointLoad);
+
+  /// Test tangent stiffness matrix for element 0 for geometrically linear case
+  const auto& ele0 = fes[0].gridElement();
+  Eigen::MatrixXd ke0;
+  ke0.setZero(4, 4);
+  calculateMatrix(fes[0], req, MatrixAffordance::stiffness, ke0);
+  const auto X1            = Dune::toEigen(ele0.geometry().corner(0));
+  const auto X2            = Dune::toEigen(ele0.geometry().corner(1));
+  const Eigen::Vector2d A1 = (X2 - X1).eval();
+  const Eigen::Vector2d A0 = {1, 0}; // horizontal axis
+  const double L0          = sqrt(A1.squaredNorm());
+  const double theta0      = std::acos(A1.dot(A0) / (A0.norm() * A1.norm()));
+  Eigen::Matrix<double, 4, 4> kbar;
+  kbar.setZero();
+  kbar(0, 0) = kbar(2, 2) = 1.0;
+  kbar(0, 2) = kbar(2, 0) = -1.0;
+  const auto Q            = rotationMatrix2D(theta0);
+  const auto k0           = (Q.transpose() * kbar * Q) * E * A / L0;
+  t.check(isApproxSame(k0, ke0, tol), "(k0 is not equal to ke0 for geometrically linear case.") << "Expected:\n"
+                                                                                                << k0 << "\nActual:\n"
+                                                                                                << ke0;
+
+  /// Choose linear solver
+  auto linSolver = LinearSolver(SolverTypeTag::d_LDLT);
+
+  NewtonRaphsonConfig<decltype(linSolver)> nrConfig{.linearSolver = linSolver};
+
+  NonlinearSolverFactory nrFactory(nrConfig);
+  auto nr = nrFactory.create(denseFlatAssembler);
+
+  /// Create Observer to write information of the non-linear solver
+  auto nonLinearSolverObserver = std::make_shared<NonLinearSolverLogger>();
+  auto nonLinOp                = Ikarus::NonLinearOperatorFactory::op(denseFlatAssembler);
+
+  t.check(utils::checkGradient(nonLinOp, {.draw = false, .writeSlopeStatementIfFailed = true}))
+      << "Check gradient failed";
+  t.check(utils::checkHessian(nonLinOp, {.draw = false, .writeSlopeStatementIfFailed = true}))
+      << "Check Hessian failed";
+
+  constexpr int loadSteps = 10;
+
+  Eigen::Matrix3Xd lambdaAndDisp;
+  lambdaAndDisp.setZero(Eigen::NoChange, loadSteps + 1);
+  /// Create Observer which executes when control routines messages
+  auto lvkObserver =
+      std::make_shared<GenericObserver<ControlMessages>>(ControlMessages::SOLUTION_CHANGED, [&](int step) {
+        lambdaAndDisp(0, step) = lambda; // load factor
+        lambdaAndDisp(1, step) = d[2];   // horizontal displacement at center node
+        lambdaAndDisp(2, step) = d[3];   // vertical displacement at center node
+      });
+
+  /// Create Observer which writes vtk files when control routines messages
+  auto vtkWriter = std::make_shared<ControlSubsamplingVertexVTKWriter<std::remove_cvref_t<decltype(basis.flat())>>>(
+      basis.flat(), d, 2);
+  vtkWriter->setFieldInfo("displacement", Dune::VTK::FieldInfo::Type::vector, 2);
+  vtkWriter->setFileNamePrefix("vonMisesTruss");
+
+  /// Create loadcontrol
+  auto lc = LoadControl(nr, loadSteps, {0, 0.5});
+  lc.nonlinearSolver().subscribeAll(nonLinearSolverObserver);
+  lc.subscribeAll({vtkWriter, lvkObserver});
+
+  /// Execute!
+  auto controlInfo = lc.run();
+  t.check(controlInfo.success == true) << "Load control failed to converge";
+
+  Eigen::VectorXd lambdaVec = lambdaAndDisp.row(0);
+  Eigen::VectorXd uVec      = lambdaAndDisp.row(1);
+  Eigen::VectorXd vVec      = -lambdaAndDisp.row(2);
+
+  // return the load factor as a function of the vertical displacement
+  auto analyticalLoadDisplacementCurve = [&](auto& v) {
+    const double Ltruss = std::sqrt(h * h + L * L);
+    return 2.0 * E * A * Dune::power(h, 3) / Dune::power(Ltruss, 3) *
+           (v / h - 1.5 * Dune::power(v / h, 2) + 0.5 * Dune::power(v / h, 3));
+  };
+
+  for (std::size_t i = 0; i < lambdaAndDisp.cols(); ++i) {
+    checkScalars(t, lambdaVec[i], analyticalLoadDisplacementCurve(vVec[i]), " Incorrect load factor", tol);
+    checkScalars(t, uVec[i], 0.0, " Incorrect horizontal displacement", tol);
+  }
+
+  double expectedAxialForce = -2.785092479363964262;
+
+  // due to the symmetry of the problem, same axial forces are expected in both elements
+  for (const auto& fe : fes) {
+    const auto N = fe.calculateAt<ResultTypes::axialForce>(req, {0.5}).asVec()[0];
+    checkScalars(t, N, expectedAxialForce, " Incorrect Axial force", tol);
+  }
+
+  return t;
+}
+
+static auto truss3dTest() {
+  TestSuite t("Truss3DTest");
+  /// Construct grid
+  auto grid     = createGrid<Grids::OneDFoamGridIn3D>();
+  auto gridView = grid->leafGridView();
+
+  /// Construct basis
+  using namespace Dune::Functions::BasisFactory;
+  auto basis      = Ikarus::makeBasis(gridView, power<3>(lagrange<1>()));
+  using LocalView = std::remove_cvref_t<decltype(basis.flat().localView())>;
+
+  /// Create finite elements
+  constexpr double E   = 2000;
+  constexpr double A   = 1000;
+  constexpr double tol = 1e-10;
+  auto sk              = skills(truss(E, A));
+  using FEType         = decltype(makeFE(basis, sk));
+  std::vector<FEType> fes;
+  for (auto&& ge : elements(gridView)) {
+    fes.emplace_back(makeFE(basis, sk));
+    fes.back().bind(ge);
+  }
+
+  /// Collect dirichlet nodes
+  auto basisP = std::make_shared<const decltype(basis)>(basis);
+  DirichletValues dirichletValues(basisP->flat());
+  dirichletValues.fixBoundaryDOFs(
+      [&](auto& dirichletFlags, auto&& globalIndex) { dirichletFlags[globalIndex] = true; });
+  std::array<LocalView::MultiIndex, 1> fixDOFs = {3}; // array containing the DOFs to be fixed at the center node
+  for (const auto dof : fixDOFs)
+    dirichletValues.setSingleDOF(dof, true);
+  t.check(dirichletValues.fixedDOFsize() == 7, "Number of fixed DOFs is not equal to 7");
+
+  /// Create assembler
+  auto denseFlatAssembler = makeDenseFlatAssembler(fes, dirichletValues);
+
+  double lambda = 1.0;
+  Eigen::VectorXd d;
+  d.setZero(basis.flat().size());
+
+  auto req = FEType::Requirement();
+  req.insertGlobalSolution(d).insertParameter(lambda);
+  denseFlatAssembler->bind(req, AffordanceCollections::elastoStatics, DBCOption::Full);
+  const auto& K = denseFlatAssembler->matrix();
+  auto R        = denseFlatAssembler->vector();
+  R[4]          = lambda;
+
+  /// Choose linear solver
+  auto linSolver = LinearSolver(SolverTypeTag::d_LDLT);
+  linSolver.compute(K);
+  linSolver.solve(d, -R);
+
+  /// Compute eigenvalues of the stiffness matrix
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> essaK;
+  essaK.compute(K);
+  auto eigenValuesComputed = essaK.eigenvalues();
+
+  Eigen::Vector2d axialForces = Eigen::Vector2d::Zero();
+  for (int i = 0; const auto& fe : fes) {
+    axialForces[i] = fe.calculateAt<ResultTypes::axialForce>(req, {0.5}).asVec()[0];
+    ++i;
+  }
+
+  Eigen::VectorXd expectedDisplacements, expectedEigenValues, expectedAxialForces;
+  expectedDisplacements.setZero(basis.flat().size());
+  expectedEigenValues.setZero(basis.flat().size());
+  expectedAxialForces.setZero(2);
+  expectedDisplacements << 0, 0, 0, 0, -0.0008521190304919996, 0.0002491175412207767, 0, 0, 0;
+  expectedEigenValues << 1, 1, 1, 1, 1, 1, 1, 1081.004736091822, 734025.9250446925;
+  expectedAxialForces << 13.785353834067782586, -14.910220788494811472;
+
+  t.check(isApproxSame(expectedEigenValues, eigenValuesComputed, tol))
+      << std::setprecision(16) << "Incorrect eigenvalues of K - Expected: " << expectedEigenValues.transpose()
+      << " Actual: " << eigenValuesComputed.transpose();
+
+  t.check(isApproxSame(expectedDisplacements, d, tol))
+      << std::setprecision(16) << "Incorrect displacements - Expected: " << expectedDisplacements.transpose()
+      << " Actual: " << d.transpose();
+
+  t.check(isApproxSame(expectedAxialForces, axialForces, tol))
+      << std::setprecision(16) << "Incorrect axial forces - Expected: " << expectedAxialForces.transpose()
+      << " Actual: " << axialForces.transpose();
+
+  return t;
+}
+
+template <int worldDim, typename GridType>
+auto trussAutoDiffTest() {
+  TestSuite t("Truss autodiff");
+  using namespace Dune::Functions::BasisFactory;
+  {
+    auto grid     = createGrid<GridType>();
+    auto gridView = grid->leafGridView();
+    t.subTest(checkFESByAutoDiff(gridView, power<worldDim>(lagrange<1>()), skills(truss(1000.0, 0.0956)),
+                                 AffordanceCollections::elastoStatics));
+  }
+  return t;
+}
+
+int main(int argc, char** argv) {
+  Ikarus::init(argc, argv);
+  TestSuite t("TrussTest");
+  t.subTest(trussAutoDiffTest<2, Grids::OneDFoamGridIn2D>());
+  t.subTest(trussAutoDiffTest<3, Grids::OneDFoamGridIn3D>());
+  t.subTest(vonMisesTrussTest());
+  t.subTest(truss3dTest());
+  return t.exit();
+}


### PR DESCRIPTION
This PR focuses on adding a nonlinear truss element along with its Python bindings. 

It also performs some additional fixes like
- `*.msh` files are also checked for lint formatting -> Modified as two `*.msh` files were added in this PR
- Removes an unnecessary `cout` statement from `nonlinearoperator.hh`
- Minor refactoring on output message displayed when a test fails, because it was hard to identify the failing terms easily in the newly added tests
- License info for `*.msh` files is also changed as `GmshReader` doesn't work if the mesh file doesn't start with `$MeshFormat`. Also adding comments anywhere else in the file, as mentioned [here](https://gmsh.info/doc/texinfo/gmsh.html#Comments) doesn't work as then the license is not identified.

I have cleaned the commits as well according to the above fixes. If anything is to be in a separate PR, I can cherry pick the commits and create them.

Open problems
- `globalIndexFromGlobalPosition` is not used in the tests as it is currently working only when `myDim == worldDim`. This must be investigated in a separate PR. The actual problem arises from this [line](https://github.com/ikarus-project/ikarus/blob/3c2869c00736877f774abcbdd8248f681ada3c7f/ikarus/utils/traversal.hh#L74). 
- `local` variable passed to the `calculateAt()` function can have a default based on `myDim`, as it is not necessary to specifiy for the current nonlinear truss element. Such defaults can also be investigated in a separate PR, as the default should probably be set in `mixin.hh`
- Currently, the user have to specifiy a "dummy" `basis` for truss to make it work. This interface can be improved while working on #228.