### PR TITLE
Add optional argument to resultfunction for precision

### DIFF
--- a/ikarus/io/resultfunction.hh
+++ b/ikarus/io/resultfunction.hh
@@ -102,6 +102,16 @@ public:
   }
 
   /**
+   * \brief Get the precision used for this result
+   * \details
+   * This function is part of the Dune::VTKFunction interface.
+   * This has no affect when the ResultFunction is used as part of a the dune-vtk module
+   * 
+   * \return Precision (i.e. float64 or float32)
+   */
+  Dune::VTK::Precision precision() const override { return prec_; }
+
+  /**
    * \brief Constructor for ResultFunction.
    * \details
    * Constructs a ResultFunction object with given finite elements, ferequirements
@@ -109,10 +119,12 @@ public:
    * \param fes Pointer to a vector of finite elements
    * \param req FERequirements for evaluation
    */
-  ResultFunction(std::vector<FiniteElement>* fes, const FERequirementType& req)
+  ResultFunction(std::vector<FiniteElement>* fes, const FERequirementType& req,
+                 Dune::VTK::Precision prec = Dune::VTK::Precision::float64)
       : gridView_{fes->at(0).localView().globalBasis().gridView()},
         feRequirements_{req},
         fes_{fes},
+        prec_{prec},
         userFunction_{UserFunction{}} {}
 
 private:
@@ -128,6 +140,7 @@ private:
   GridView gridView_;
   FERequirementType feRequirements_;
   std::vector<FiniteElement>* fes_;
+  Dune::VTK::Precision prec_;
   [[no_unique_address]] std::string name_{};
   UserFunction userFunction_;
 };
@@ -145,8 +158,9 @@ private:
  * \tparam UserFunction Type of the user-defined function for custom result evaluation (default is DefaultUserFunction)
  */
 template <template <typename, int, int> class RT, typename UserFunction = Impl::DefaultUserFunction, typename FE>
-auto makeResultFunction(std::vector<FE>* fes, const typename FE::Requirement& req) {
-  return std::make_shared<ResultFunction<FE, RT, UserFunction>>(fes, req);
+auto makeResultFunction(std::vector<FE>* fes, const typename FE::Requirement& req,
+                        Dune::VTK::Precision prec = Dune::VTK::Precision::float64) {
+  return std::make_shared<ResultFunction<FE, RT, UserFunction>>(fes, req, prec);
 }
 
 /**

--- a/ikarus/io/resultfunction.hh
+++ b/ikarus/io/resultfunction.hh
@@ -106,7 +106,7 @@ public:
    * \details
    * This function is part of the Dune::VTKFunction interface.
    * This has no affect when the ResultFunction is used as part of a the dune-vtk module
-   * 
+   *
    * \return Precision (i.e. float64 or float32)
    */
   Dune::VTK::Precision precision() const override { return prec_; }

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -35,6 +35,7 @@ set(programSourceFiles
     testpythonconversion.cpp
     testshellthicknessquadrule.cpp
     testtrustregion.cpp
+        testresultfunction.cpp
 )
 
 set(TEST_DEPENDING_ON_LOCALFEFUNCTIONS
@@ -47,6 +48,8 @@ set(TEST_DEPENDING_ON_LOCALFEFUNCTIONS
     testnonlinearelasticityneohooke
     testnonlinearelasticitysvk
     testadaptivestepsizing
+        testresultfunction.cpp
+
 )
 # Compile only tests
 dune_add_test(

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -35,7 +35,7 @@ set(programSourceFiles
     testpythonconversion.cpp
     testshellthicknessquadrule.cpp
     testtrustregion.cpp
-        testresultfunction.cpp
+    testresultfunction.cpp
 )
 
 set(TEST_DEPENDING_ON_LOCALFEFUNCTIONS
@@ -48,8 +48,7 @@ set(TEST_DEPENDING_ON_LOCALFEFUNCTIONS
     testnonlinearelasticityneohooke
     testnonlinearelasticitysvk
     testadaptivestepsizing
-        testresultfunction.cpp
-
+    testresultfunction.cpp
 )
 # Compile only tests
 dune_add_test(

--- a/tests/src/testresultfunction.cpp
+++ b/tests/src/testresultfunction.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <config.h>
+
+#include "testcommon.hh"
+
+#include <memory>
+
+#include <dune/common/float_cmp.hh>
+#include <dune/common/fvector.hh>
+#include <dune/common/test/testsuite.hh>
+#include <dune/functions/functionspacebases/lagrangebasis.hh>
+#include <dune/functions/functionspacebases/powerbasis.hh>
+#include <dune/grid/common/entity.hh>
+#include <dune/grid/io/file/vtk/vtkwriter.hh>
+#include <dune/grid/uggrid.hh>
+#include <dune/grid/yaspgrid.hh>
+#include <dune/vtk/datacollectors/discontinuousdatacollector.hh>
+#include <dune/vtk/types.hh>
+#include <dune/vtk/vtkreader.hh>
+
+#include <Eigen/Core>
+
+#include <ikarus/assembler/simpleassemblers.hh>
+#include "ikarus/finiteelements/feresulttypes.hh"
+#include <ikarus/finiteelements/fefactory.hh>
+#include <ikarus/finiteelements/mechanics/linearelastic.hh>
+#include <ikarus/finiteelements/mechanics/loads/volume.hh>
+#include <ikarus/finiteelements/mixin.hh>
+#include <ikarus/io/resultfunction.hh>
+#include <ikarus/utils/basis.hh>
+#include <ikarus/utils/dirichletvalues.hh>
+#include <ikarus/utils/init.hh>
+using Dune::TestSuite;
+
+auto expectedStressValues(Dune::Vtk::DataTypes precision) -> std::vector<double> {
+  if (precision == Dune::Vtk::DataTypes::FLOAT32)
+    return {-0.612563, -3.06282,   -0.178688,  -0.605305,  -3.02653,   1.40567e-16, -0.165843,   -2.97347,
+            -0.164172, -0.158585,  -2.93718,   0.0145161,  -0.605305,  -3.02653,    1.40567e-16, -0.612563,
+            -3.06282,  0.178688,   -0.158585,  -2.93718,   -0.0145161, -0.165843,   -2.97347,    0.164172,
+            0.250011,  -0.894201,  0.122203,   0.218461,   -1.05195,   0.0145161,   -0.0192071,  -0.948045,
+            0.0591021, -0.0507578, -1.1058,    -0.0485852, 0.218461,   -1.05195,    -0.0145161,  0.250011,
+            -0.894201, -0.122203,  -0.0507578, -1.1058,    0.0485852,  -0.0192071,  -0.948045,   -0.0591021};
+  // Float64
+  return {
+      -0.612563441928246,    -3.06281720964123,    -0.1786881422641234,  -0.6053053722981661,  -3.02652686149083,
+      1.405665430359793e-16, 0.2500112482565204,   -0.8942014658868807,  0.1222034745688248,   0.2184605681421391,
+      -1.051954866458787,    -0.01451613926015979, -0.6053053722981661,  -3.02652686149083,    1.405665430359793e-16,
+      -0.6125634419282462,   -3.06281720964123,    0.1786881422641237,   0.2184605681421391,   -1.051954866458787,
+      -0.01451613926015979,  0.2500112482565203,   -0.894201465886881,   -0.1222034745688246,  0.2500112482565204,
+      -0.8942014658868807,   0.1222034745688248,   0.2184605681421391,   -1.051954866458787,   -0.01451613926015979,
+      -0.01920709001514156,  -0.948045133541213,   0.05910211434006233,  -0.05075777012952284, -1.105798534113119,
+      0.04858522096860256,   0.2184605681421391,   -1.051954866458787,   -0.01451613926015979, 0.2500112482565203,
+      -0.894201465886881,    -0.1222034745688246,  -0.05075777012952284, -1.105798534113119,   0.04858522096860256,
+      -0.01920709001514165,  -0.9480451335412133,  -0.05910211434006224};
+}
+
+auto testFile(const std::string& fileName, Dune::Vtk::DataTypes precision) {
+  TestSuite t("Test read in grid");
+  auto epsilon = precision == Dune::Vtk::DataTypes::FLOAT32 ? 1e-6 : 1e-8;
+
+  using Grid = Dune::UGGrid<2>;
+  Dune::GridFactory<Grid> factory;
+
+  Dune::Vtk::VtkReader reader{factory};
+  reader.read(fileName);
+  auto grid     = reader.createGrid();
+  auto gridView = grid->leafGridView();
+
+  t.check(gridView.size(0) == 4) << "GridView should have 4 elements, but has " << gridView.size(0) << " elements";
+
+  // get point Data
+  auto stressData = reader.getPointData("linearStress");
+
+  t.check(stressData.numComponents() == 3) << "Num components should be 3, but is " << stressData.numComponents();
+  t.check(stressData.dataType() == precision) << "Precision is wrong";
+  std::cout << "New\n";
+  auto localStressFunction = localFunction(stressData);
+  auto results             = expectedStressValues(precision);
+  for (int i = 0; const auto& ele : Dune::elements(gridView)) {
+    localStressFunction.bind(ele);
+    auto refEle = Dune::referenceElement(ele);
+    for (const auto c : Dune::range(ele.geometry().corners())) {
+      auto corner       = refEle.geometry<2>(c).center();
+      auto stressInFile = localStressFunction(corner);
+      for (const auto j : Dune::range(3)) {
+        t.check(Dune::FloatCmp::eq(stressInFile[j], results[i], epsilon))
+            << "Result read in is " << stressInFile[j] << "but should be " << results[i];
+        ++i;
+      }
+    }
+  }
+
+  return t;
+}
+
+auto runTestCase() {
+  TestSuite t("Test ResultFunction");
+  std::string fileName = "ResultFunctionTest";
+
+  using Grid = Dune::UGGrid<2>;
+  using GridView = Grid::LeafGridView;
+
+  constexpr double Lx                     = 4.0;
+  constexpr double Ly                     = 4.0;
+  const Dune::FieldVector<double, 2> bbox = {Lx, Ly};
+  const std::array<unsigned int, 2> elementsPerDirection   = {2, 2};
+
+  auto grid = Dune::StructuredGridFactory<Grid>::createCubeGrid({0, 0}, bbox, elementsPerDirection);
+  auto gridView                           = grid->leafGridView();
+
+  using namespace Dune::Functions::BasisFactory;
+  auto basis = Ikarus::makeBasis(gridView, power<2>(lagrange<1>()));
+
+  Ikarus::DirichletValues dirichletValues(basis.flat());
+  dirichletValues.fixBoundaryDOFs([&](auto& dirichletFlags, auto&& localIndex, auto&& localView, auto&& intersection) {
+    if (std::abs(intersection.geometry().center()[1]) < 1e-8)
+      dirichletFlags[localView.index(localIndex)] = true;
+  });
+
+  auto vL      = []([[maybe_unused]] auto& globalCoord, auto& lamb) { return Eigen::Vector2d{0, -1}; };
+  auto skills_ = Ikarus::skills(Ikarus::linearElastic({.emodul = 100, .nu = 0.2}), Ikarus::volumeLoad<2>(vL));
+
+  using LinearElastic = decltype(Ikarus::makeFE(basis, skills_));
+  std::vector<LinearElastic> fes;
+
+  for (auto&& element : elements(gridView)) {
+    fes.emplace_back(Ikarus::makeFE(basis, skills_));
+    fes.back().bind(element);
+  }
+
+  /// Create a sparse assembler
+  auto sparseAssembler = Ikarus::SparseFlatAssembler(fes, dirichletValues);
+
+  Eigen::VectorXd D_Glob = Eigen::VectorXd::Zero(basis.flat().size());
+
+  auto req = Ikarus::FERequirements().addAffordance(Ikarus::AffordanceCollections::elastoStatics);
+
+  auto residualFunction = [&](auto&& disp_, auto&& lambdaLocal) -> auto& {
+    req.insertGlobalSolution(Ikarus::FESolutions::displacement, disp_)
+        .insertParameter(Ikarus::FEParameter::loadfactor, lambdaLocal);
+    return sparseAssembler.getVector(req);
+  };
+
+  auto KFunction = [&](auto&& disp_, auto&& lambdaLocal) -> auto& {
+    req.insertGlobalSolution(Ikarus::FESolutions::displacement, disp_)
+        .insertParameter(Ikarus::FEParameter::loadfactor, lambdaLocal);
+    return sparseAssembler.getMatrix(req);
+  };
+
+  double lambdaLoad = 1.0;
+  auto nonLinOp =
+      Ikarus::NonLinearOperator(Ikarus::functions(residualFunction, KFunction), Ikarus::parameter(D_Glob, lambdaLoad));
+  const auto& K    = nonLinOp.derivative();
+  const auto& Fext = nonLinOp.value();
+
+  auto linSolver = Ikarus::LinearSolver(Ikarus::SolverTypeTag::sd_CholmodSupernodalLLT);
+  linSolver.compute(K);
+  linSolver.solve(D_Glob, -Fext);
+  req.insertGlobalSolution(Ikarus::FESolutions::displacement, D_Glob);
+
+  auto stressFunction    = Ikarus::makeResultFunction<Ikarus::ResultTypes::linearStress>(&fes, req);
+  auto stressVtkFunction = Ikarus::makeResultVtkFunction<Ikarus::ResultTypes::linearStress>(&fes, req);
+
+  // Test
+  // Dune::VTKWriter will always default to FLOAT32
+  Dune::VTKWriter vtkWriter(gridView, Dune::VTK::nonconforming);
+  vtkWriter.addVertexData(stressFunction);
+  vtkWriter.write(fileName + "_Common_VTK_32");
+  t.subTest(testFile(fileName + "_Common_VTK_32" + ".vtu", Dune::Vtk::DataTypes::FLOAT32));
+
+  // Passing float64 doens't change it
+  Dune::VTKWriter vtkWriter4(gridView, Dune::VTK::nonconforming, Dune::VTK::Precision::float64);
+  vtkWriter4.addVertexData(stressFunction);
+  vtkWriter4.write(fileName + "_Common_VTK_64");
+  t.subTest(testFile(fileName + "_Common_VTK_64" + ".vtu", Dune::Vtk::DataTypes::FLOAT32));
+
+  // Vtk::VtkWriter can be told to use a special Datatype
+  Dune::Vtk::UnstructuredGridWriter<GridView, Dune::Vtk::DiscontinuousDataCollector<GridView>>
+      vtkWriter2(gridView, Dune::Vtk::FormatTypes::ASCII, Dune::Vtk::DataTypes::FLOAT32);
+  vtkWriter2.addPointData(stressVtkFunction);
+  auto vtkfileName = vtkWriter2.write(fileName + "_Vtk_32");
+  t.subTest(testFile(vtkfileName, Dune::Vtk::DataTypes::FLOAT32));
+
+  Dune::Vtk::UnstructuredGridWriter vtkwriter5(gridView);
+  vtkwriter5.write(fileName + "_5");
+  //
+  // Dune::Vtk::UnstructuredGridWriter vtkWriter3(gridView, Dune::Vtk::FormatTypes::ASCII, Dune::Vtk::DataTypes::FLOAT64);
+  // vtkWriter3.addPointData(stressVtkFunction);
+  // auto vtkfileName3 = vtkWriter3.write(fileName + "_Vtk_64");
+  // t.subTest(testFile(vtkfileName3, Dune::Vtk::DataTypes::FLOAT64));
+
+  return t;
+}
+
+int main(const int argc, char** argv) {
+  Ikarus::init(argc, argv);
+  TestSuite t;
+
+  t.subTest(runTestCase());
+
+  return t.exit();
+}

--- a/tests/src/testresultfunction.cpp
+++ b/tests/src/testresultfunction.cpp
@@ -34,7 +34,7 @@
 #include <ikarus/utils/init.hh>
 using Dune::TestSuite;
 
-auto expectedStressValues(Dune::Vtk::DataTypes precision) -> std::vector<double> {
+auto expectedStressValues(Dune::Vtk::DataTypes precision, bool native) -> std::vector<double> {
   if (precision == Dune::Vtk::DataTypes::FLOAT32)
     return {-0.612563, -3.06282,   -0.178688,  -0.605305,  -3.02653,   1.40567e-16, -0.165843,   -2.97347,
             -0.164172, -0.158585,  -2.93718,   0.0145161,  -0.605305,  -3.02653,    1.40567e-16, -0.612563,
@@ -42,7 +42,19 @@ auto expectedStressValues(Dune::Vtk::DataTypes precision) -> std::vector<double>
             0.250011,  -0.894201,  0.122203,   0.218461,   -1.05195,   0.0145161,   -0.0192071,  -0.948045,
             0.0591021, -0.0507578, -1.1058,    -0.0485852, 0.218461,   -1.05195,    -0.0145161,  0.250011,
             -0.894201, -0.122203,  -0.0507578, -1.1058,    0.0485852,  -0.0192071,  -0.948045,   -0.0591021};
-  // Float64
+
+  if (precision == Dune::Vtk::DataTypes::FLOAT64 and native)
+    return {-0.612563441928246,   -3.06281720964123,  -0.178688142264123,  -0.605305372298166,  -3.02652686149083,
+            1.40566543035979e-16, -0.165843086267937, -2.97347313850917,   -0.164172003003964,  -0.158585016637857,
+            -2.93718279035877,    0.0145161392601598, -0.605305372298166,  -3.02652686149083,   1.40566543035979e-16,
+            -0.612563441928246,   -3.06281720964123,  0.178688142264124,   -0.158585016637857,  -2.93718279035877,
+            -0.0145161392601598,  -0.165843086267937, -2.97347313850917,   0.164172003003964,   0.25001124825652,
+            -0.894201465886881,   0.122203474568825,  0.218460568142139,   -1.05195486645879,   0.0145161392601599,
+            -0.0192070900151417,  -0.948045133541213, 0.0591021143400626,  -0.0507577701295228, -1.10579853411312,
+            -0.0485852209686023,  0.218460568142139,  -1.05195486645879,   -0.0145161392601597, 0.25001124825652,
+            -0.894201465886881,   -0.122203474568824, -0.0507577701295225, -1.10579853411312,   0.0485852209686022,
+            -0.0192070900151415,  -0.948045133541214, -0.0591021143400625};
+
   return {
       -0.612563441928246,    -3.06281720964123,    -0.1786881422641234,  -0.6053053722981661,  -3.02652686149083,
       1.405665430359793e-16, 0.2500112482565204,   -0.8942014658868807,  0.1222034745688248,   0.2184605681421391,
@@ -56,9 +68,9 @@ auto expectedStressValues(Dune::Vtk::DataTypes precision) -> std::vector<double>
       -0.01920709001514165,  -0.9480451335412133,  -0.05910211434006224};
 }
 
-auto testFile(const std::string& fileName, Dune::Vtk::DataTypes precision) {
+auto testFile(const std::string& fileName, Dune::Vtk::DataTypes precision, bool native) {
   TestSuite t("Test read in grid");
-  auto epsilon = precision == Dune::Vtk::DataTypes::FLOAT32 ? 1e-6 : 1e-8;
+  auto epsilon = precision == Dune::Vtk::DataTypes::FLOAT32 ? 1e-4 : 1e-8;
 
   using Grid = Dune::UGGrid<2>;
   Dune::GridFactory<Grid> factory;
@@ -75,9 +87,9 @@ auto testFile(const std::string& fileName, Dune::Vtk::DataTypes precision) {
 
   t.check(stressData.numComponents() == 3) << "Num components should be 3, but is " << stressData.numComponents();
   t.check(stressData.dataType() == precision) << "Precision is wrong";
-  std::cout << "New\n";
+
   auto localStressFunction = localFunction(stressData);
-  auto results             = expectedStressValues(precision);
+  auto results             = expectedStressValues(precision, native);
   for (int i = 0; const auto& ele : Dune::elements(gridView)) {
     localStressFunction.bind(ele);
     auto refEle = Dune::referenceElement(ele);
@@ -99,16 +111,16 @@ auto runTestCase() {
   TestSuite t("Test ResultFunction");
   std::string fileName = "ResultFunctionTest";
 
-  using Grid = Dune::UGGrid<2>;
+  using Grid     = Dune::UGGrid<2>;
   using GridView = Grid::LeafGridView;
 
-  constexpr double Lx                     = 4.0;
-  constexpr double Ly                     = 4.0;
-  const Dune::FieldVector<double, 2> bbox = {Lx, Ly};
-  const std::array<unsigned int, 2> elementsPerDirection   = {2, 2};
+  constexpr double Lx                                    = 4.0;
+  constexpr double Ly                                    = 4.0;
+  const Dune::FieldVector<double, 2> bbox                = {Lx, Ly};
+  const std::array<unsigned int, 2> elementsPerDirection = {2, 2};
 
-  auto grid = Dune::StructuredGridFactory<Grid>::createCubeGrid({0, 0}, bbox, elementsPerDirection);
-  auto gridView                           = grid->leafGridView();
+  auto grid     = Dune::StructuredGridFactory<Grid>::createCubeGrid({0, 0}, bbox, elementsPerDirection);
+  auto gridView = grid->leafGridView();
 
   using namespace Dune::Functions::BasisFactory;
   auto basis = Ikarus::makeBasis(gridView, power<2>(lagrange<1>()));
@@ -131,65 +143,68 @@ auto runTestCase() {
   }
 
   /// Create a sparse assembler
-  auto sparseAssembler = Ikarus::SparseFlatAssembler(fes, dirichletValues);
+  auto sparseAssembler = makeSparseFlatAssembler(fes, dirichletValues);
 
   Eigen::VectorXd D_Glob = Eigen::VectorXd::Zero(basis.flat().size());
 
-  auto req = Ikarus::FERequirements().addAffordance(Ikarus::AffordanceCollections::elastoStatics);
+  auto req        = LinearElastic::Requirement();
+  auto lambdaLoad = 1.0;
+  req.insertGlobalSolution(D_Glob).insertParameter(lambdaLoad);
 
-  auto residualFunction = [&](auto&& disp_, auto&& lambdaLocal) -> auto& {
-    req.insertGlobalSolution(Ikarus::FESolutions::displacement, disp_)
-        .insertParameter(Ikarus::FEParameter::loadfactor, lambdaLocal);
-    return sparseAssembler.getVector(req);
-  };
+  sparseAssembler->bind(req);
+  sparseAssembler->bind(Ikarus::DBCOption::Full);
 
-  auto KFunction = [&](auto&& disp_, auto&& lambdaLocal) -> auto& {
-    req.insertGlobalSolution(Ikarus::FESolutions::displacement, disp_)
-        .insertParameter(Ikarus::FEParameter::loadfactor, lambdaLocal);
-    return sparseAssembler.getMatrix(req);
-  };
+  auto nonLinOp = Ikarus::NonLinearOperatorFactory::op(
+      sparseAssembler,
+      Ikarus::AffordanceCollection(Ikarus::VectorAffordance::forces, Ikarus::MatrixAffordance::stiffness));
 
-  double lambdaLoad = 1.0;
-  auto nonLinOp =
-      Ikarus::NonLinearOperator(Ikarus::functions(residualFunction, KFunction), Ikarus::parameter(D_Glob, lambdaLoad));
   const auto& K    = nonLinOp.derivative();
   const auto& Fext = nonLinOp.value();
 
   auto linSolver = Ikarus::LinearSolver(Ikarus::SolverTypeTag::sd_CholmodSupernodalLLT);
   linSolver.compute(K);
   linSolver.solve(D_Glob, -Fext);
-  req.insertGlobalSolution(Ikarus::FESolutions::displacement, D_Glob);
 
-  auto stressFunction    = Ikarus::makeResultFunction<Ikarus::ResultTypes::linearStress>(&fes, req);
+  // If we initialize result function as VTKFunction we can specify precision, this doesn't affect it when we use it
+  // with Dune::Vtk
+  auto stressFunction32 =
+      Ikarus::makeResultFunction<Ikarus::ResultTypes::linearStress>(&fes, req, Dune::VTK::Precision::float32);
+  auto stressFunction64 =
+      Ikarus::makeResultFunction<Ikarus::ResultTypes::linearStress>(&fes, req, Dune::VTK::Precision::float64);
   auto stressVtkFunction = Ikarus::makeResultVtkFunction<Ikarus::ResultTypes::linearStress>(&fes, req);
 
   // Test
   // Dune::VTKWriter will always default to FLOAT32
   Dune::VTKWriter vtkWriter(gridView, Dune::VTK::nonconforming);
-  vtkWriter.addVertexData(stressFunction);
+  vtkWriter.addVertexData(stressFunction32);
   vtkWriter.write(fileName + "_Common_VTK_32");
-  t.subTest(testFile(fileName + "_Common_VTK_32" + ".vtu", Dune::Vtk::DataTypes::FLOAT32));
 
-  // Passing float64 doens't change it
+  std::cout << "Testing now Common_VTK_32" << std::endl;
+  t.subTest(testFile(fileName + "_Common_VTK_32" + ".vtu", Dune::Vtk::DataTypes::FLOAT32, true));
+
+  // You can change coord precision to float64 in the constructor
   Dune::VTKWriter vtkWriter4(gridView, Dune::VTK::nonconforming, Dune::VTK::Precision::float64);
-  vtkWriter4.addVertexData(stressFunction);
+  vtkWriter4.addVertexData(stressFunction64);
   vtkWriter4.write(fileName + "_Common_VTK_64");
-  t.subTest(testFile(fileName + "_Common_VTK_64" + ".vtu", Dune::Vtk::DataTypes::FLOAT32));
+
+  std::cout << "Testing now Common_VTK_64" << std::endl;
+  t.subTest(testFile(fileName + "_Common_VTK_64" + ".vtu", Dune::Vtk::DataTypes::FLOAT64, true));
 
   // Vtk::VtkWriter can be told to use a special Datatype
-  Dune::Vtk::UnstructuredGridWriter<GridView, Dune::Vtk::DiscontinuousDataCollector<GridView>>
-      vtkWriter2(gridView, Dune::Vtk::FormatTypes::ASCII, Dune::Vtk::DataTypes::FLOAT32);
+  Dune::Vtk::UnstructuredGridWriter<GridView, Dune::Vtk::DiscontinuousDataCollector<GridView>> vtkWriter2(
+      gridView, Dune::Vtk::FormatTypes::ASCII, Dune::Vtk::DataTypes::FLOAT32);
   vtkWriter2.addPointData(stressVtkFunction);
   auto vtkfileName = vtkWriter2.write(fileName + "_Vtk_32");
-  t.subTest(testFile(vtkfileName, Dune::Vtk::DataTypes::FLOAT32));
 
-  Dune::Vtk::UnstructuredGridWriter vtkwriter5(gridView);
-  vtkwriter5.write(fileName + "_5");
-  //
-  // Dune::Vtk::UnstructuredGridWriter vtkWriter3(gridView, Dune::Vtk::FormatTypes::ASCII, Dune::Vtk::DataTypes::FLOAT64);
-  // vtkWriter3.addPointData(stressVtkFunction);
-  // auto vtkfileName3 = vtkWriter3.write(fileName + "_Vtk_64");
-  // t.subTest(testFile(vtkfileName3, Dune::Vtk::DataTypes::FLOAT64));
+  std::cout << "Testing now Vtk_32" << std::endl;
+  t.subTest(testFile(vtkfileName, Dune::Vtk::DataTypes::FLOAT32, false));
+
+  Dune::Vtk::UnstructuredGridWriter vtkWriter3(gridView, Dune::Vtk::FormatTypes::ASCII, Dune::Vtk::DataTypes::FLOAT64);
+  vtkWriter3.addPointData(stressVtkFunction);
+  auto vtkfileName3 = vtkWriter3.write(fileName + "_Vtk_64");
+
+  std::cout << "Testing now Vtk_64" << std::endl;
+  t.subTest(testFile(vtkfileName3, Dune::Vtk::DataTypes::FLOAT64, false));
 
   return t;
 }


### PR DESCRIPTION
There are some tests detailing how to get the precision you want for your output. 
For DuneVTK we default to float64, for Dune::Vtk we have to specify manually

This PR is in preparation for #287 