### PR TITLE
Hotfix: Size property of assembler & assemblermanipulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ python/pyikarus.egg-info/
 dist/
 _skbuild/
 MANIFEST.in
-ikarus/python/test/*.vtu
+*.vtu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   ([#304](https://github.com/ikarus-project/ikarus/pull/304))
     - This can be used, for instance, to apply concentrated forces or to add spring stiffness in a particular direction.
     - Furthermore, a helper function to get the global index of a Lagrange node at the given global position is added.
-- Rework Python Interface for `DirichletValues` plus adding support to easily fix boundary DOFs of subspacebasis in C++ and Python ([#305](https://github.com/ikarus-project/ikarus/pull/305))
 - Rework the Python Interface for `DirichletValues` plus add support to easily fix boundary DOFs of `Subspacebasis` in C++ and Python ([#305](https://github.com/ikarus-project/ikarus/pull/305))
 
 ## Release v0.4 (Ganymede)

--- a/ikarus/assembler/assemblermanipulatorfuser.hh
+++ b/ikarus/assembler/assemblermanipulatorfuser.hh
@@ -86,6 +86,7 @@ public:
   using WrappedAssembler::dBCOption;
   using WrappedAssembler::reducedSize;
   using WrappedAssembler::requirement;
+  using WrappedAssembler::size;
 
   // functions from implementations
   using ScalarAssemblerImpl::bind;
@@ -171,6 +172,7 @@ public:
   using WrappedAssembler::dBCOption;
   using WrappedAssembler::reducedSize;
   using WrappedAssembler::requirement;
+  using WrappedAssembler::size;
 
   // functions from implementations
   using ScalarAssemblerImpl::bind;
@@ -275,6 +277,7 @@ public:
   using WrappedAssembler::dBCOption;
   using WrappedAssembler::reducedSize;
   using WrappedAssembler::requirement;
+  using WrappedAssembler::size;
 
   // functions from implementations
   using MatrixAssemblerImpl::bind;

--- a/ikarus/assembler/assemblermanipulatorfuser.hh
+++ b/ikarus/assembler/assemblermanipulatorfuser.hh
@@ -83,7 +83,10 @@ public:
   using WrappedAssembler::createFullVector;
 
   using WrappedAssembler::affordanceCollection;
+  using WrappedAssembler::constraintsBelow;
   using WrappedAssembler::dBCOption;
+  using WrappedAssembler::estimateOfConnectivity;
+  using WrappedAssembler::isConstrained;
   using WrappedAssembler::reducedSize;
   using WrappedAssembler::requirement;
   using WrappedAssembler::size;
@@ -169,7 +172,10 @@ public:
   using WrappedAssembler::createFullVector;
 
   using WrappedAssembler::affordanceCollection;
+  using WrappedAssembler::constraintsBelow;
   using WrappedAssembler::dBCOption;
+  using WrappedAssembler::estimateOfConnectivity;
+  using WrappedAssembler::isConstrained;
   using WrappedAssembler::reducedSize;
   using WrappedAssembler::requirement;
   using WrappedAssembler::size;
@@ -274,7 +280,10 @@ public:
   using WrappedAssembler::createFullVector;
 
   using WrappedAssembler::affordanceCollection;
+  using WrappedAssembler::constraintsBelow;
   using WrappedAssembler::dBCOption;
+  using WrappedAssembler::estimateOfConnectivity;
+  using WrappedAssembler::isConstrained;
   using WrappedAssembler::reducedSize;
   using WrappedAssembler::requirement;
   using WrappedAssembler::size;
@@ -345,16 +354,17 @@ auto makeAssemblerManipulator(A&& a) {
   constexpr bool vec  = Concepts::VectorFlatAssembler<std::remove_cvref_t<A>>;
   constexpr bool mat  = Concepts::MatrixFlatAssembler<std::remove_cvref_t<A>>;
   if constexpr (scal && vec && mat)
-    return AssemblerManipulator<std::remove_cvref_t<A>,
-                                Impl::AssemblerInterfaceHelper<ScalarAssembler, ScalarManipulator>,
-                                Impl::AssemblerInterfaceHelper<VectorAssembler, VectorManipulator>,
-                                Impl::AssemblerInterfaceHelper<MatrixAssembler, MatrixManipulator>>(std::forward<A>(a));
+    return std::make_shared<
+        AssemblerManipulator<std::remove_cvref_t<A>, Impl::AssemblerInterfaceHelper<ScalarAssembler, ScalarManipulator>,
+                             Impl::AssemblerInterfaceHelper<VectorAssembler, VectorManipulator>,
+                             Impl::AssemblerInterfaceHelper<MatrixAssembler, MatrixManipulator>>>(std::forward<A>(a));
   else if constexpr (scal && vec)
-    return AssemblerManipulator<std::remove_cvref_t<A>,
-                                Impl::AssemblerInterfaceHelper<ScalarAssembler, ScalarManipulator>,
-                                Impl::AssemblerInterfaceHelper<VectorAssembler, VectorManipulator>>(std::forward<A>(a));
+    return std::make_shared<
+        AssemblerManipulator<std::remove_cvref_t<A>, Impl::AssemblerInterfaceHelper<ScalarAssembler, ScalarManipulator>,
+                             Impl::AssemblerInterfaceHelper<VectorAssembler, VectorManipulator>>>(std::forward<A>(a));
   else if constexpr (scal)
-    return AssemblerManipulator<std::remove_cvref_t<A>,
-                                Impl::AssemblerInterfaceHelper<ScalarAssembler, ScalarManipulator>>(std::forward<A>(a));
+    return std::make_shared<AssemblerManipulator<std::remove_cvref_t<A>,
+                                                 Impl::AssemblerInterfaceHelper<ScalarAssembler, ScalarManipulator>>>(
+        std::forward<A>(a));
 }
 } // namespace Ikarus

--- a/ikarus/assembler/assemblermanipulatorfuser.hh
+++ b/ikarus/assembler/assemblermanipulatorfuser.hh
@@ -73,6 +73,7 @@ public:
   using typename WrappedAssembler::FEContainer;
   using typename WrappedAssembler::FERequirement;
   using typename WrappedAssembler::ScalarType;
+  using typename WrappedAssembler::SizeType;
 
   // functions from FlatAssemblerBase
   using WrappedAssembler::bind;
@@ -161,6 +162,7 @@ public:
   using typename WrappedAssembler::FEContainer;
   using typename WrappedAssembler::FERequirement;
   using typename WrappedAssembler::ScalarType;
+  using typename WrappedAssembler::SizeType;
   using typename WrappedAssembler::VectorType;
 
   // functions from FlatAssemblerBase
@@ -269,6 +271,7 @@ public:
   using typename WrappedAssembler::FERequirement;
   using typename WrappedAssembler::MatrixType;
   using typename WrappedAssembler::ScalarType;
+  using typename WrappedAssembler::SizeType;
   using typename WrappedAssembler::VectorType;
 
   // functions from FlatAssemblerBase

--- a/ikarus/python/assembler/flatassembler.hh
+++ b/ikarus/python/assembler/flatassembler.hh
@@ -45,6 +45,8 @@ void registerFlatAssembler(pybind11::handle scope, pybind11::class_<Assembler, o
   using DirichletValuesType      = typename Assembler::DirichletValuesType;
   using AffordanceCollectionType = typename Assembler::AffordanceCollectionType;
   using FERequirementType        = typename Assembler::FERequirement;
+  using SizeType                 = typename Assembler::SizeType;
+
   cls.def(pybind11::init([](const pybind11::list& fes, const DirichletValuesType& dirichletValues) {
             /*here a copy of the whole vector of fes takes place! There is no way to prevent this if we want that
              * the user can pass native python lists here, see
@@ -116,6 +118,8 @@ void registerFlatAssembler(pybind11::handle scope, pybind11::class_<Assembler, o
   cls.def("dBCOption", [](Assembler& self) { return self.dBCOption(); });
   cls.def_property_readonly("size", [](Assembler& self) { return self.size(); });
   cls.def("__len__", [](Assembler& self) { return self.size(); });
+  cls.def("constraintsBelow", [](Assembler& self, SizeType i) { return self.constraintsBelow(i); });
+  cls.def("isConstrained", [](Assembler& self, SizeType i) { return self.isConstrained(i); });
 }
 
 #define MAKE_ASSEMBLER_REGISTERY_FUNCTION(name)                                              \

--- a/ikarus/python/assembler/flatassembler.hh
+++ b/ikarus/python/assembler/flatassembler.hh
@@ -114,6 +114,8 @@ void registerFlatAssembler(pybind11::handle scope, pybind11::class_<Assembler, o
   cls.def("requirement", [](Assembler& self) { return self.requirement(); });
   cls.def("affordanceCollection", [](Assembler& self) { return self.affordanceCollection(); });
   cls.def("dBCOption", [](Assembler& self) { return self.dBCOption(); });
+  cls.def_property_readonly("size", [](Assembler& self) { return self.size(); });
+  cls.def("__len__", [](Assembler& self) { return self.size(); });
 }
 
 #define MAKE_ASSEMBLER_REGISTERY_FUNCTION(name)                                              \

--- a/ikarus/python/test/linearelastictest.py
+++ b/ikarus/python/test/linearelastictest.py
@@ -162,39 +162,65 @@ def linElasticTest(easBool):
     assemblerManipulatorDense = iks.assembler.assemblerManipulator(assemblerDense)
 
     if not easBool:
-        def scalarf(assembler,req,affordance,scalar):
-            scalar*=2
+
+        def scalarf(assembler, req, affordance, scalar):
+            scalar *= 2
+
         assemblerManipulator.addScalarCallBack(scalarf)
         assemblerManipulatorDense.addScalarCallBack(scalarf)
         req3 = assemblerManipulator.requirement()
-        d3= req3.globalSolution()
-        d3 +=1
-        assert abs(2*assembler.scalar() - assemblerManipulator.scalar())<1e-6, f"assembler.scalar(): {assembler.scalar()}, assemblerManipulator.scalar(): {assemblerManipulator.scalar()}"
-        assert abs(2*assembler.scalar() - assemblerManipulatorDense.scalar())<1e-6, f"assembler.scalar(): {assembler.scalar()}, assemblerManipulator.scalar(): {assemblerManipulatorDense.scalar()}"
+        d3 = req3.globalSolution()
+        d3 += 1
+        assert (
+            abs(2 * assembler.scalar() - assemblerManipulator.scalar()) < 1e-6
+        ), f"assembler.scalar(): {assembler.scalar()}, assemblerManipulator.scalar(): {assemblerManipulator.scalar()}"
+        assert (
+            abs(2 * assembler.scalar() - assemblerManipulatorDense.scalar()) < 1e-6
+        ), f"assembler.scalar(): {assembler.scalar()}, assemblerManipulator.scalar(): {assemblerManipulatorDense.scalar()}"
 
-    def vectorf(assembler,req,affordance,dbcOption,vector):
-        vector[5]+=2
+    def vectorf(assembler, req, affordance, dbcOption, vector):
+        vector[5] += 2
+
     assemblerManipulator.addVectorCallBack(vectorf)
     assemblerManipulatorDense.addVectorCallBack(vectorf)
-    assert abs(assembler.vector()[5] - (assemblerManipulator.vector()[5]-2))<1e-6, f"assembler.vector()[5]: {assembler.vector()[5]}, assemblerManipulator.vector()[5]: {assemblerManipulator.vector()[5]}"
-    assert abs(assembler.vector()[5] - (assemblerManipulatorDense.vector()[5]-2))<1e-6, f"assembler.vector()[5]: {assembler.vector()[5]}, assemblerManipulator.vector()[5]: {assemblerManipulatorDense.vector()[5]}"
+    assert (
+        abs(assembler.vector()[5] - (assemblerManipulator.vector()[5] - 2)) < 1e-6
+    ), f"assembler.vector()[5]: {assembler.vector()[5]}, assemblerManipulator.vector()[5]: {assemblerManipulator.vector()[5]}"
+    assert (
+        abs(assembler.vector()[5] - (assemblerManipulatorDense.vector()[5] - 2)) < 1e-6
+    ), f"assembler.vector()[5]: {assembler.vector()[5]}, assemblerManipulator.vector()[5]: {assemblerManipulatorDense.vector()[5]}"
 
-    def matrixf(assembler,req,affordance,dbcOption,matrix):
-        matrix[5,6]=matrix[5,6]+2.0
+    def matrixf(assembler, req, affordance, dbcOption, matrix):
+        matrix[5, 6] = matrix[5, 6] + 2.0
+
     assemblerManipulator.addMatrixCallBack(matrixf)
     assemblerManipulatorDense.addMatrixCallBack(matrixf)
-    assert abs(assembler.matrix()[5,6] - (assemblerManipulator.matrix()[5,6]-2))<1e-6, f"assembler.matrix()[5,6]: {assembler.matrix()[5,6]}, assemblerManipulator.matrix()[5,6]: {assemblerManipulator.matrix()[5,6]}"
-    assert abs(assembler.matrix()[5,6] - (assemblerManipulatorDense.matrix()[5,6]-2))<1e-6, f"assembler.matrix()[5,6]: {assembler.matrix()[5,6]}, assemblerManipulator.matrix()[5,6]: {assemblerManipulatorDense.matrix()[5,6]}"
+    assert (
+        abs(assembler.matrix()[5, 6] - (assemblerManipulator.matrix()[5, 6] - 2)) < 1e-6
+    ), f"assembler.matrix()[5,6]: {assembler.matrix()[5,6]}, assemblerManipulator.matrix()[5,6]: {assemblerManipulator.matrix()[5,6]}"
+    assert (
+        abs(assembler.matrix()[5, 6] - (assemblerManipulatorDense.matrix()[5, 6] - 2))
+        < 1e-6
+    ), f"assembler.matrix()[5,6]: {assembler.matrix()[5,6]}, assemblerManipulator.matrix()[5,6]: {assemblerManipulatorDense.matrix()[5,6]}"
 
-    startX=-1
-    incX=2/3
-    startY=-1
-    incY=2/3
+    startX = -1
+    incX = 2 / 3
+    startY = -1
+    incY = 2 / 3
     for j in range(4):
         for i in range(4):
-            indices= iks.utils.globalIndexFromGlobalPosition(flatBasis,(startX+i*incX,startY+j*incY))
-            assert indices[0]==i+4*j, f"Expected {i+4*j} from {i},{j}, got {indices[0]} at pos {(startX+i*incX,startY+j*incY)}"
-            assert indices[1]==i+4*j+16, f"Expected {i+4*j+16} from {i},{j}, got {indices[1]} at pos {(startX+i*incX,startY+j*incY)}"
+            indices = iks.utils.globalIndexFromGlobalPosition(
+                flatBasis, (startX + i * incX, startY + j * incY)
+            )
+            assert (
+                indices[0] == i + 4 * j
+            ), f"Expected {i+4*j} from {i},{j}, got {indices[0]} at pos {(startX+i*incX,startY+j*incY)}"
+            assert (
+                indices[1] == i + 4 * j + 16
+            ), f"Expected {i+4*j+16} from {i},{j}, got {indices[1]} at pos {(startX+i*incX,startY+j*incY)}"
+
+    assert assembler.size == assemblerManipulator.size == flatBasis.size()
+    assert len(assembler) == len(assemblerManipulator) == len(flatBasis)
 
 
 if __name__ == "__main__":

--- a/ikarus/python/test/linearelastictest.py
+++ b/ikarus/python/test/linearelastictest.py
@@ -222,6 +222,8 @@ def linElasticTest(easBool):
     assert assembler.size == assemblerManipulator.size == flatBasis.size()
     assert len(assembler) == len(assemblerManipulator) == len(flatBasis)
 
+    assert assembler.isConstrained(1) == assemblerManipulator.isConstrained(1) == dirichletValues.isConstrained(1)
+    assert assembler.constraintsBelow(i) == assemblerManipulator.constraintsBelow(i)
 
 if __name__ == "__main__":
     linElasticTest(easBool=False)

--- a/ikarus/utils/functionhelper.hh
+++ b/ikarus/utils/functionhelper.hh
@@ -72,7 +72,7 @@ auto globalIndexFromGlobalPosition(const Basis& basis, const Dune::FieldVector<d
   };
   forEachLagrangeNodePosition(localView, fT);
   if (not globalIndices.has_value())
-    DUNE_THROW(Dune::GridError, "No Lagrange node found at the given position in the grid.");
+    DUNE_THROW(Dune::InvalidStateException, "No Lagrange node found at the given position in the grid.");
   return globalIndices.value();
 }
 

--- a/ikarus/utils/nonlinopfactory.hh
+++ b/ikarus/utils/nonlinopfactory.hh
@@ -104,7 +104,7 @@ struct NonLinearOperatorFactory
     } else {
       if (not as.bound())
         ex();
-      return op(std::forward<Assembler>(as), as.requirement(), as.affordanceCollection(), as->dBCOption());
+      return op(std::forward<Assembler>(as), as.requirement(), as.affordanceCollection(), as.dBCOption());
     }
   }
 

--- a/python/ikarus/assembler/__init__.py
+++ b/python/ikarus/assembler/__init__.py
@@ -59,7 +59,7 @@ def assemblerManipulator(assembler):
 
     @return: The created assembler manipulator.
     """
-    element_type = f"decltype(Ikarus::makeAssemblerManipulator(std::declval<{assembler.cppTypeName}>()))"
+    element_type = f"decltype(Ikarus::makeAssemblerManipulator(std::declval<{assembler.cppTypeName}>()))::element_type"
     generator = MySimpleGenerator("AssemblerManipulator", "Ikarus::Python")
 
     includes = []

--- a/tests/src/testassembler.cpp
+++ b/tests/src/testassembler.cpp
@@ -81,7 +81,7 @@ auto SimpleAssemblersTest(const PreBasis& preBasis) {
     Dune::FieldVector<double, 2> pos{2.0, 1.0};
     int centerNode = 1; // number of nodes at the center ( = pos)
     if (Ikarus::Concepts::LagrangeNodeOfOrder<ChildType, 1> and ref == 0) {
-      t.checkThrow<Dune::GridError>(
+      t.checkThrow<Dune::InvalidFutureException>(
           [&]() { auto fixIndices = utils::globalIndexFromGlobalPosition(basis.flat(), pos); },
           "globalIndexFromGlobalPosition should have failed for order = 1 and ref = 0 as no node exists at "
           "the center.");

--- a/tests/src/testassembler.cpp
+++ b/tests/src/testassembler.cpp
@@ -217,40 +217,40 @@ auto SimpleAssemblersTest(const PreBasis& preBasis) {
         mat.diagonal()[globalIndices[1]] += springStiffness;
       };
 
-      scalarFlatAssemblerAM.bind(doubleEnergy);
+      scalarFlatAssemblerAM->bind(doubleEnergy);
 
-      vectorFlatAssemblerAM.bind(pointLoad);
+      vectorFlatAssemblerAM->bind(pointLoad);
 
-      sparseFlatAssemblerAM.bind(doubleEnergy);
-      sparseFlatAssemblerAM.bind(pointLoad);
-      sparseFlatAssemblerAM.bind(addSpringStiffnessSparse);
+      sparseFlatAssemblerAM->bind(doubleEnergy);
+      sparseFlatAssemblerAM->bind(pointLoad);
+      sparseFlatAssemblerAM->bind(addSpringStiffnessSparse);
 
-      denseFlatAssemblerAM.bind(doubleEnergy);
-      denseFlatAssemblerAM.bind(doubleEnergy); // doubled twice
-      denseFlatAssemblerAM.bind(pointLoad);
-      denseFlatAssemblerAM.bind(addSpringStiffnessDense);
+      denseFlatAssemblerAM->bind(doubleEnergy);
+      denseFlatAssemblerAM->bind(doubleEnergy); // doubled twice
+      denseFlatAssemblerAM->bind(pointLoad);
+      denseFlatAssemblerAM->bind(addSpringStiffnessDense);
 
-      const auto& mKRawDense = denseFlatAssemblerAM.matrix(req, MatrixAffordance::stiffness, DBCOption::Raw);
-      const auto& mKRaw      = sparseFlatAssemblerAM.matrix(req, MatrixAffordance::stiffness, DBCOption::Raw);
-      const auto& mRRawDense = denseFlatAssemblerAM.vector(req, VectorAffordance::forces, DBCOption::Raw);
-      const auto& mRRaw      = sparseFlatAssemblerAM.vector(req, VectorAffordance::forces, DBCOption::Raw);
-      const auto& mRVecRaw   = vectorFlatAssemblerAM.vector(req, VectorAffordance::forces, DBCOption::Raw);
+      const auto& mKRawDense = denseFlatAssemblerAM->matrix(req, MatrixAffordance::stiffness, DBCOption::Raw);
+      const auto& mKRaw      = sparseFlatAssemblerAM->matrix(req, MatrixAffordance::stiffness, DBCOption::Raw);
+      const auto& mRRawDense = denseFlatAssemblerAM->vector(req, VectorAffordance::forces, DBCOption::Raw);
+      const auto& mRRaw      = sparseFlatAssemblerAM->vector(req, VectorAffordance::forces, DBCOption::Raw);
+      const auto& mRVecRaw   = vectorFlatAssemblerAM->vector(req, VectorAffordance::forces, DBCOption::Raw);
       checkAssembledQuantities(t, mKRaw, mKRawDense, totalDOFs);
       checkAssembledQuantities(t, mRRaw, mRRawDense, totalDOFs);
       checkAssembledQuantities(t, mRVecRaw, mRRawDense, totalDOFs);
 
-      const auto& mKDense = denseFlatAssemblerAM.matrix(req, MatrixAffordance::stiffness, DBCOption::Full);
-      const auto& mK      = sparseFlatAssemblerAM.matrix(req, MatrixAffordance::stiffness, DBCOption::Full);
-      const auto& mRDense = denseFlatAssemblerAM.vector(req, VectorAffordance::forces, DBCOption::Full);
-      const auto& mR      = sparseFlatAssemblerAM.vector(req, VectorAffordance::forces, DBCOption::Full);
-      const auto& mRVec   = vectorFlatAssemblerAM.vector(req, VectorAffordance::forces, DBCOption::Full);
+      const auto& mKDense = denseFlatAssemblerAM->matrix(req, MatrixAffordance::stiffness, DBCOption::Full);
+      const auto& mK      = sparseFlatAssemblerAM->matrix(req, MatrixAffordance::stiffness, DBCOption::Full);
+      const auto& mRDense = denseFlatAssemblerAM->vector(req, VectorAffordance::forces, DBCOption::Full);
+      const auto& mR      = sparseFlatAssemblerAM->vector(req, VectorAffordance::forces, DBCOption::Full);
+      const auto& mRVec   = vectorFlatAssemblerAM->vector(req, VectorAffordance::forces, DBCOption::Full);
       checkAssembledQuantities(t, mK, mKDense, totalDOFs);
       checkAssembledQuantities(t, mR, mRDense, totalDOFs);
       checkAssembledQuantities(t, mRVec, mRDense, totalDOFs);
 
-      const double mEnergyDense = denseFlatAssemblerAM.scalar(req, ScalarAffordance::mechanicalPotentialEnergy);
-      const double mEnergy      = sparseFlatAssemblerAM.scalar(req, ScalarAffordance::mechanicalPotentialEnergy);
-      const double mEnergySca   = scalarFlatAssemblerAM.scalar(req, ScalarAffordance::mechanicalPotentialEnergy);
+      const double mEnergyDense = denseFlatAssemblerAM->scalar(req, ScalarAffordance::mechanicalPotentialEnergy);
+      const double mEnergy      = sparseFlatAssemblerAM->scalar(req, ScalarAffordance::mechanicalPotentialEnergy);
+      const double mEnergySca   = scalarFlatAssemblerAM->scalar(req, ScalarAffordance::mechanicalPotentialEnergy);
       checkScalars(t, mEnergy * 2, mEnergyDense, " Incorrect energies for manipulated sparse and dense assemblers");
       checkScalars(t, mEnergySca * 2, mEnergyDense, " Incorrect energies for manipulated scalar and dense assemblers");
       checkScalars(t, mEnergy, 2.0 * energy, " Incorrect energy for sparse assembler after manipulation");

--- a/tests/src/testassembler.cpp
+++ b/tests/src/testassembler.cpp
@@ -81,7 +81,7 @@ auto SimpleAssemblersTest(const PreBasis& preBasis) {
     Dune::FieldVector<double, 2> pos{2.0, 1.0};
     int centerNode = 1; // number of nodes at the center ( = pos)
     if (Ikarus::Concepts::LagrangeNodeOfOrder<ChildType, 1> and ref == 0) {
-      t.checkThrow<Dune::InvalidFutureException>(
+      t.checkThrow<Dune::InvalidStateException>(
           [&]() { auto fixIndices = utils::globalIndexFromGlobalPosition(basis.flat(), pos); },
           "globalIndexFromGlobalPosition should have failed for order = 1 and ref = 0 as no node exists at "
           "the center.");


### PR DESCRIPTION
During merging my PR I noticed that the size property for assemblermanipulator was not working, so this is a hotfix for that