### PR TITLE
add .clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+# SPDX-License-Identifier: CC0-1.0
+CompileFlags:                                         # Tweak the parse settings
+  Add: -include=build/config.h                        # Add config.h to parse first 
+  Remove: -fext-numeric-literals*                     # strip all other warning-related flags


### PR DESCRIPTION
This enhances the clangd langauge server. 

`Add: -include=build/config.h`
 - Now preprocessor directives declared in config.h are processed

`Remove: -fext-numeric-literals`
 - fixes a clangd issue where a error would always appear at the top of the file regarding unknown arguments (see screenshot) 
![348639412-8294e4f4-6597-41bf-91ba-8553a02b3911](https://github.com/user-attachments/assets/d45946fc-4ae7-4e8a-b1d7-187282ac7d0b)

 (see also https://stackoverflow.com/questions/39178288/why-dont-complex-number-literals-work-in-clang) 
