### PR TITLE
fix python formatting + versions of formatters

### DIFF
--- a/.github/workflows/createDockerContainer.yml
+++ b/.github/workflows/createDockerContainer.yml
@@ -17,7 +17,7 @@
      runs-on: ubuntu-latest
 
      steps:
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@v4
          with:
            repository: 'ikarus-project/ikarus-docker-container'
            path: 'repo'

--- a/.github/workflows/debian-coverage.yml
+++ b/.github/workflows/debian-coverage.yml
@@ -32,7 +32,7 @@ jobs:
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build
         run: |
           mkdir $HOME/profiles/

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -73,7 +73,7 @@ jobs:
             testRegex: "python"
           }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
          path: 'repo'
       - name: Build

--- a/.github/workflows/docsDryRun.yml
+++ b/.github/workflows/docsDryRun.yml
@@ -19,7 +19,7 @@ jobs:
       image: ikarusproject/ikarus-dev:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: 'repo'
       - uses: actions/setup-python@v4

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -16,7 +16,7 @@ jobs:
       image: ikarusproject/ikarus-dev:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: 'repo'
       - uses: actions/setup-python@v4

--- a/.github/workflows/runExamples.yml
+++ b/.github/workflows/runExamples.yml
@@ -48,7 +48,7 @@ jobs:
             testRegex: "cpp"
           }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
          path: 'repo'
       - name: Install Ikarus

--- a/.github/workflows/scripts/release.py
+++ b/.github/workflows/scripts/release.py
@@ -23,10 +23,10 @@ def bump_patch_number(version_number: str) -> str:
     """Return a copy of `version_number` with the patch number incremented."""
     version_number_array = version_number.split(".")
 
-    if len(version_number_array)==2:
+    if len(version_number_array) == 2:
         major, minor = version_number_array
-        patch  =0
-    elif len(version_number_array)==3:
+        patch = 0
+    elif len(version_number_array) == 3:
         major, minor, patch = version_number_array
     else:
         raise Exception("Bad versoin number passed!")

--- a/.github/workflows/scripts/updatelicense.py
+++ b/.github/workflows/scripts/updatelicense.py
@@ -50,7 +50,7 @@ def process_directory(directory):
     for root, _, files in os.walk(directory):
         for file in files:
             file_path = os.path.join(root, file)
-            if os.path.basename(file_path) == 'dep5':
+            if os.path.basename(file_path) == "dep5":
                 update_dep5(file_path)
             else:
                 update_license_header(file_path)

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v2
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
          path: 'repo'
       - name: Install format dependencies
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Validating lowercase file names
         uses: scheduleonce/lint-filenames@v2.0.0
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,10 +35,10 @@ jobs:
          path: 'repo'
       - name: Install format dependencies
         run: |
-          pip install clang-format
+          pip install clang-format==18.1.8
           clang-format --version
           pip install cmake_format==0.6.13 pyyaml
-          pip install black==23.3.0
+          pip install black==24.4.2
 
       - name: configure
         run: cmake -S "cmake/FormatTarget" -Bbuild -DADD_FORMATTARGET=TRUE -DADD_PYTHONFORMATTING=1
@@ -47,7 +47,7 @@ jobs:
         run: |
           cmake --build build --target format
           cmake --build build --target check-format
-          cmake --build build --target check-pythonformat
+          python -m black . --check
 
   REUSE:
     name: REUSE Compliance Check

--- a/ikarus/python/test/debug_info.py
+++ b/ikarus/python/test/debug_info.py
@@ -1,13 +1,18 @@
 # SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
+
 os.environ["DUNE_LOG_LEVEL"] = "debug"
 os.environ["DUNE_SAVE_BUILD"] = "terminal"
 
+
 def setDebugFlags():
     import dune.generator as generator
-    generator.setFlags("-g ",noChecks=False)
+
+    generator.setFlags("-g ", noChecks=False)
+
 
 def unsetDebugFlags():
     import dune.generator as generator
+
     generator.reset()

--- a/ikarus/python/test/kltest.py
+++ b/ikarus/python/test/kltest.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 import debug_info
+
 debug_info.setDebugFlags()
 import ikarus as iks
 from ikarus import finite_elements, assembler
@@ -66,11 +67,13 @@ if __name__ == "__main__":
 
     vLoad = iks.finite_elements.volumeLoad3D(vL)
 
-    klShell = iks.finite_elements.kirchhoffLoveShell(youngs_modulus=1000, nu=0.0,thickness=thickness)
+    klShell = iks.finite_elements.kirchhoffLoveShell(
+        youngs_modulus=1000, nu=0.0, thickness=thickness
+    )
 
     fes = []
     for e in gridView.elements:
-        fes.append(iks.finite_elements.makeFE(basis,klShell,vLoad))
+        fes.append(iks.finite_elements.makeFE(basis, klShell, vLoad))
         fes[-1].bind(e)
 
     dirichletValues = iks.dirichletValues(flatBasis)
@@ -88,11 +91,11 @@ if __name__ == "__main__":
 
     def gradAndhess(dRedInput):
         req = fes[0].createRequirement()
-        req.insertParameter( lambdaLoad)
+        req.insertParameter(lambdaLoad)
         dBig = assembler.createFullVector(dRedInput)
-        req.insertGlobalSolution( dBig)
-        g = assembler.vector(req,iks.VectorAffordance.forces, iks.DBCOption.Reduced)
-        h = assembler.matrix(req,iks.MatrixAffordance.stiffness, iks.DBCOption.Reduced)
+        req.insertGlobalSolution(dBig)
+        g = assembler.vector(req, iks.VectorAffordance.forces, iks.DBCOption.Reduced)
+        h = assembler.matrix(req, iks.MatrixAffordance.stiffness, iks.DBCOption.Reduced)
         return [g, h]
 
     from numpy.linalg import norm
@@ -115,4 +118,6 @@ if __name__ == "__main__":
     vtkWriter = gridView.trimmedVtkWriter()
     vtkWriter.addPointData(displacementFunc, name="displacement")
     vtkWriter.write("KLshell")
-    assert (0.2087577577980777 - max(d)) < 1e-6, f"The maximum displacement should be 0.2087577577980777 but is {max(d)}"
+    assert (
+        0.2087577577980777 - max(d)
+    ) < 1e-6, f"The maximum displacement should be 0.2087577577980777 but is {max(d)}"

--- a/ikarus/python/test/linearelastictest.py
+++ b/ikarus/python/test/linearelastictest.py
@@ -222,8 +222,13 @@ def linElasticTest(easBool):
     assert assembler.size == assemblerManipulator.size == flatBasis.size()
     assert len(assembler) == len(assemblerManipulator) == len(flatBasis)
 
-    assert assembler.isConstrained(1) == assemblerManipulator.isConstrained(1) == dirichletValues.isConstrained(1)
+    assert (
+        assembler.isConstrained(1)
+        == assemblerManipulator.isConstrained(1)
+        == dirichletValues.isConstrained(1)
+    )
     assert assembler.constraintsBelow(i) == assemblerManipulator.constraintsBelow(i)
+
 
 if __name__ == "__main__":
     linElasticTest(easBool=False)

--- a/python/ikarus/__init__.py
+++ b/python/ikarus/__init__.py
@@ -15,14 +15,18 @@ except ImportError:
     pass
 
 
-
 import warnings
 from ._ikarus import *
 from .dirichlet_values import dirichletValues
 from .basis import basis
 
 from warnings import warn
+
+
 def ValueWrapper(*args, **kwargs):
-    warnings.warn("The 'ValueWrapper' class was renamed to Scalar. Please use 'Scalar' instead.",
-                  DeprecationWarning, stacklevel=2 )
+    warnings.warn(
+        "The 'ValueWrapper' class was renamed to Scalar. Please use 'Scalar' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _ikarus.Scalar(*args, **kwargs)

--- a/python/ikarus/assembler/__init__.py
+++ b/python/ikarus/assembler/__init__.py
@@ -4,6 +4,7 @@
 from dune.common.hashit import hashIt
 from ikarus.generator import MySimpleGenerator
 
+
 def sparseFlatAssembler(fes, dirichletValues):
     """
     @brief Creates a sparse flat assembler for the given finite elements and Dirichlet values.
@@ -50,6 +51,7 @@ def denseFlatAssembler(fes, dirichletValues):
         includes=includes, typeName=element_type, moduleName=moduleName
     )
     return module.DenseFlatAssembler(fes, dirichletValues)
+
 
 def assemblerManipulator(assembler):
     """

--- a/python/ikarus/basis.py
+++ b/python/ikarus/basis.py
@@ -6,6 +6,7 @@ from dune.functions.globalbasis import preBasisTypeName
 from dune.functions import defaultGlobalBasis
 from .generator import MySimpleGenerator
 
+
 def basis(gv, tree):
     """
     @brief Creates a basis handler for the given grid view and tree.

--- a/python/ikarus/dirichlet_values.py
+++ b/python/ikarus/dirichlet_values.py
@@ -27,7 +27,9 @@ def __fixBoundaryDOFs(dirichletValues):
         return dirichletValues.fixBoundaryDOFs(functor_, {prefixPathType}{{}});
           }});
         }}
-        """.format(prefixPathType=prefixPathTypeName)
+        """.format(
+            prefixPathType=prefixPathTypeName
+        )
         return run("fixBoundaryDofs", StringIO(runCode), dirichletValues, f)
 
     return __fixBoundaryDOFsFunc
@@ -50,7 +52,10 @@ def dirichletValues(basis):
     includes += ["ikarus/python/dirichletvalues/dirichletvalues.hh"]
     moduleName = "dirichletValues_" + hashIt(element_type)
     module = generator.load(
-        includes=includes, typeName=element_type, moduleName=moduleName, dynamicAttr=True
+        includes=includes,
+        typeName=element_type,
+        moduleName=moduleName,
+        dynamicAttr=True,
     )
 
     dv = module.DirichletValues(basis)

--- a/python/ikarus/finite_elements/__init__.py
+++ b/python/ikarus/finite_elements/__init__.py
@@ -4,6 +4,7 @@
 from dune.common.hashit import hashIt
 from ikarus.generator import MySimpleGenerator
 
+
 def registerPreElement(name, includes, element_type, *args):
     """
     @brief Registers a pre-element with the specified parameters.
@@ -26,6 +27,7 @@ def registerPreElement(name, includes, element_type, *args):
     f = getattr(module, name)
     return f(*args)
 
+
 def volumeLoad(f, d: int):
     """
     @brief Creates a volume load pre-element for the specified dimension.
@@ -43,6 +45,7 @@ def volumeLoad(f, d: int):
     element_type = f"Ikarus::VolumeLoadPre<{d}>"
     return registerPreElement("VolumeLoadPre", includes, element_type, f)
 
+
 def volumeLoad1D(f):
     """
     @brief Creates a 1D volume load pre-element.
@@ -52,6 +55,7 @@ def volumeLoad1D(f):
     @return: The registered 1D volume load pre-element function.
     """
     return volumeLoad(f, 1)
+
 
 def volumeLoad2D(f):
     """
@@ -63,6 +67,7 @@ def volumeLoad2D(f):
     """
     return volumeLoad(f, 2)
 
+
 def volumeLoad3D(f):
     """
     @brief Creates a 3D volume load pre-element.
@@ -72,6 +77,7 @@ def volumeLoad3D(f):
     @return: The registered 3D volume load pre-element function.
     """
     return volumeLoad(f, 3)
+
 
 def neumannBoundaryLoad(boundaryPatch, f):
     """
@@ -87,8 +93,13 @@ def neumannBoundaryLoad(boundaryPatch, f):
     includes += ["dune/python/pybind11/stl.h"]
     includes += ["dune/python/pybind11/eigen.h"]
     includes += boundaryPatch._includes
-    element_type = f"Ikarus::NeumannBoundaryLoadPre<{boundaryPatch.gridView().cppTypeName}>"
-    return registerPreElement("NeumannBoundaryLoadPre", includes, element_type, boundaryPatch, f)
+    element_type = (
+        f"Ikarus::NeumannBoundaryLoadPre<{boundaryPatch.gridView().cppTypeName}>"
+    )
+    return registerPreElement(
+        "NeumannBoundaryLoadPre", includes, element_type, boundaryPatch, f
+    )
+
 
 def nonLinearElastic(mat):
     """
@@ -104,6 +115,7 @@ def nonLinearElastic(mat):
     includes += mat._includes
     return registerPreElement("NonLinearElasticPre", includes, element_type, mat)
 
+
 def linearElastic(youngs_modulus, nu):
     """
     @brief Creates a linear elastic pre-element.
@@ -115,7 +127,10 @@ def linearElastic(youngs_modulus, nu):
     """
     includes = ["ikarus/finiteelements/mechanics/linearelastic.hh"]
     element_type = "Ikarus::LinearElasticPre"
-    return registerPreElement("LinearElasticPre", includes, element_type, youngs_modulus, nu)
+    return registerPreElement(
+        "LinearElasticPre", includes, element_type, youngs_modulus, nu
+    )
+
 
 def truss(youngs_modulus, cross_section):
     """
@@ -128,7 +143,10 @@ def truss(youngs_modulus, cross_section):
     """
     includes = ["ikarus/finiteelements/mechanics/truss.hh"]
     element_type = "Ikarus::TrussPre"
-    return registerPreElement("TrussPre", includes, element_type, youngs_modulus, cross_section)
+    return registerPreElement(
+        "TrussPre", includes, element_type, youngs_modulus, cross_section
+    )
+
 
 def eas(numberofparameters):
     """
@@ -140,7 +158,10 @@ def eas(numberofparameters):
     """
     includes = ["ikarus/finiteelements/mechanics/enhancedassumedstrains.hh"]
     element_type = "Ikarus::EnhancedAssumedStrainsPre"
-    return registerPreElement("EnhancedAssumedStrainsPre", includes, element_type, numberofparameters)
+    return registerPreElement(
+        "EnhancedAssumedStrainsPre", includes, element_type, numberofparameters
+    )
+
 
 def kirchhoffLoveShell(youngs_modulus: float, nu, thickness):
     """
@@ -154,7 +175,10 @@ def kirchhoffLoveShell(youngs_modulus: float, nu, thickness):
     """
     includes = ["ikarus/finiteelements/mechanics/kirchhoffloveshell.hh"]
     element_type = "Ikarus::KirchhoffLoveShellPre"
-    return registerPreElement("KirchhoffLoveShellPre", includes, element_type, youngs_modulus, nu, thickness)
+    return registerPreElement(
+        "KirchhoffLoveShellPre", includes, element_type, youngs_modulus, nu, thickness
+    )
+
 
 def makeFE(basis, *skills):
     """

--- a/python/ikarus/utils/__init__.py
+++ b/python/ikarus/utils/__init__.py
@@ -4,6 +4,7 @@
 from dune.common.hashit import hashIt
 from ikarus.generator import MySimpleGenerator
 
+
 def boundaryPatch(gridView, booleanVector):
     """
     @brief Creates a boundary patch for the given grid view and boolean vector.
@@ -26,9 +27,11 @@ def boundaryPatch(gridView, booleanVector):
     )
     return module.BoundaryPatch(gridView, booleanVector)
 
+
 from io import StringIO
 from dune.generator.algorithm import run
 from dune.common import FieldVector
+
 
 def globalIndexFromGlobalPosition(basis, pos):
 


### PR DESCRIPTION
This goes hand in hand with https://github.com/ikarus-project/ikarus-docker-container/pull/9

For that we have to fix the format of a few files (2dn commit)

Ive also bumped the version of actions/checkout@v2 to get rid of the warning
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, scheduleonce/lint-filenames@v2.0.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```


When running the python formatting target, everything seems to work. But when it is run via the CI, it can't find any python files, thats why I channged it in the action to just use black without the cmake target

See CI: https://github.com/ikarus-project/ikarus/actions/runs/10095821887/job/27916876109
```
18s
Run cmake --build build --target format
clang-format did not modify any files
Built target clang-format
Built target cmake-format
Built target format
clang-format did not modify any files
Built target check-clang-format
Built target check-cmake-format
Built target check-format
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: black in /home/runner/.local/lib/python3.10/site-packages (23.3.0)
Requirement already satisfied: mypy-extensions>=0.4.3 in /home/runner/.local/lib/python3.10/site-packages (from black) (1.0.0)
Requirement already satisfied: tomli>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from black) (2.0.1)
Requirement already satisfied: click>=8.0.0 in /usr/lib/python3/dist-packages (from black) (8.0.3)
Requirement already satisfied: packaging>=22.0 in /usr/local/lib/python3.10/dist-packages (from black) (24.1)
Requirement already satisfied: platformdirs>=2 in /usr/local/lib/python3.10/dist-packages (from black) (4.2.2)
Requirement already satisfied: pathspec>=0.9.0 in /home/runner/.local/lib/python3.10/site-packages (from black) (0.12.1)
No Python files are present to be formatted. Nothing to do 😴
Built target check-pythonformat
```
