### PR TITLE
Fix building Python bindings with Clang 

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -26,7 +26,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container:
-      image: henrij22/ikarus-dev-clang:latest
+      image: henrij22/dunebase-clang:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     strategy:
       fail-fast: false

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -22,11 +22,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  Build:
+  Build-Clang:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container:
-      image: ikarusproject/ikarus-dev:latest # this does not work for the python binding tests since the dune base bindings are configured with gcc and here ikarus her executed with clang, we may use ikarus-dev-clang later here
+      image: henrij22/ikarus-dev-clang:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     strategy:
       fail-fast: false
@@ -49,13 +49,48 @@ jobs:
               testRegex: "cpp",
             }
           - {
-              name: "Gcc-12-Debug",
-              config: Debug,
-              compilerC: gcc-12,
-              compilerCxx: g++-12,
-              lib: "",
-              testRegex: "cpp_quick",
-            }
+            name: "Clang-12-Python",
+            config: Release,
+            compilerC: clang-16,
+            compilerCxx: clang++-16,
+            lib: "-stdlib=libc++",
+            testRegex: "python"
+           }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         path: 'repo'
+      - name: Build
+        working-directory: ./repo
+        run: |
+          mkdir cmake-build-${{ matrix.config.config }}
+          cd cmake-build-${{ matrix.config.config }}
+          cmake ../  -DCMAKE_BUILD_TYPE=${{ matrix.config.config }} -GNinja -DCMAKE_C_COMPILER=${{ matrix.config.compilerC }} -DCMAKE_CXX_COMPILER=${{ matrix.config.compilerCxx }}
+          cmake --build . --parallel 2 --target ikarus
+          cmake --build . --parallel 2 --target _ikarus
+          cmake --build . --parallel 2 --target build_${{ matrix.config.testRegex }}_tests
+      - name: Tests
+        working-directory: ./repo/cmake-build-${{ matrix.config.config }}
+        run: ctest --output-on-failure --parallel 2 -L ${{ matrix.config.testRegex }}
+
+  Build-Gcc:
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ikarusproject/ikarus-dev:latest
+      options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "Gcc-12-Debug",
+            config: Debug,
+            compilerC: gcc-12,
+            compilerCxx: g++-12,
+            lib: "",
+            testRegex: "cpp_quick"
+          }
           - {
               name: "Gcc-12-Release",
               config: Release,

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -22,94 +22,73 @@ on:
   workflow_dispatch:
 
 env:
-  IKARUS_PYTHON_TEST_BUILD_TYPE: 'Release'
+  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: 'Release'
 
 jobs:
-  Build-Clang:
+  Build:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
-    container:
-      image: ikarusproject/ikarus-dev-clang:latest
-      options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     strategy:
       fail-fast: false
       matrix:
         config:
           - {
               name: "Clang-16-Debug",
+              container: "ikarusproject/ikarus-dev-clang:latest",
               config: Debug,
               compilerC: clang-16,
               compilerCxx: clang++-16,
               lib: "-stdlib=libc++",
-              testRegex: "cpp_quick",
+              testRegex: "cpp_quick"
             }
           - {
               name: "Clang-16-Release",
+              container: "ikarusproject/ikarus-dev-clang:latest",
               config: Release,
               compilerC: clang-16,
               compilerCxx: clang++-16,
               lib: "-stdlib=libc++",
-              testRegex: "cpp",
+              testRegex: "cpp"
             }
           - {
-            name: "Clang-16-Python",
-            config: Release,
-            compilerC: clang-16,
-            compilerCxx: clang++-16,
-            lib: "-stdlib=libc++",
-            testRegex: "python"
-           }
-    steps:
-      - uses: actions/checkout@v4
-        with:
-         path: 'repo'
-      - name: Build
-        working-directory: ./repo
-        run: |
-          mkdir cmake-build-${{ matrix.config.config }}
-          cd cmake-build-${{ matrix.config.config }}
-          cmake ../  -DCMAKE_BUILD_TYPE=${{ matrix.config.config }} -GNinja -DCMAKE_C_COMPILER=${{ matrix.config.compilerC }} -DCMAKE_CXX_COMPILER=${{ matrix.config.compilerCxx }}
-          cmake --build . --parallel 2 --target ikarus
-          cmake --build . --parallel 2 --target _ikarus
-          cmake --build . --parallel 2 --target build_${{ matrix.config.testRegex }}_tests
-      - name: Tests
-        working-directory: ./repo/cmake-build-${{ matrix.config.config }}
-        run: ctest --output-on-failure --parallel 2 -L ${{ matrix.config.testRegex }}
-
-  Build-Gcc:
-    name: ${{ matrix.config.name }}
-    runs-on: ubuntu-latest
-    container:
-      image: ikarusproject/ikarus-dev-gcc:latest
-      options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
+              name: "Clang-16-Python",
+              container: "ikarusproject/ikarus-dev-clang:latest",
+              config: Release,
+              compilerC: clang-16,
+              compilerCxx: clang++-16,
+              lib: "-stdlib=libc++",
+              testRegex: "python"
+            }
           - {
-            name: "Gcc-12-Debug",
-            config: Debug,
-            compilerC: gcc-12,
-            compilerCxx: g++-12,
-            lib: "",
-            testRegex: "cpp_quick"
-          }
+              name: "Gcc-12-Debug",
+              container: "ikarusproject/ikarus-dev-gcc:latest",
+              config: Debug,
+              compilerC: gcc-12,
+              compilerCxx: g++-12,
+              lib: "",
+              testRegex: "cpp_quick"
+            }
           - {
               name: "Gcc-12-Release",
+              container: "ikarusproject/ikarus-dev-gcc:latest",
               config: Release,
               compilerC: gcc-12,
               compilerCxx: g++-12,
               lib: "",
-              testRegex: "cpp",
+              testRegex: "cpp"
             }
           - {
               name: "Gcc-12-Python",
+              container: "ikarusproject/ikarus-dev-gcc:latest",
               config: Release,
               compilerC: gcc-12,
               compilerCxx: g++-12,
               lib: "",
-              testRegex: "python",
+              testRegex: "python"
             }
+    container:
+      image: ${{ matrix.config.container }}
+      options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -21,9 +21,6 @@ on:
       - "**.md"
   workflow_dispatch:
 
-env:
-  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: "Release"
-
 jobs:
   Build:
     name: ${{ matrix.config.name }}
@@ -51,9 +48,18 @@ jobs:
               testRegex: "cpp",
             }
           - {
-              name: "Clang-16-Python",
+              name: "Clang-16-Python-Release",
               container: "ikarusproject/ikarus-dev-clang:latest",
               config: Release,
+              compilerC: clang-16,
+              compilerCxx: clang++-16,
+              lib: "-stdlib=libc++",
+              testRegex: "python",
+            }
+          - {
+              name: "Clang-16-Python-Debug",
+              container: "ikarusproject/ikarus-dev-clang:latest",
+              config: Debug,
               compilerC: clang-16,
               compilerCxx: clang++-16,
               lib: "-stdlib=libc++",
@@ -78,7 +84,7 @@ jobs:
               testRegex: "cpp",
             }
           - {
-              name: "Gcc-12-Python",
+              name: "Gcc-12-Python-Release",
               container: "ikarusproject/ikarus-dev-gcc:latest",
               config: Release,
               compilerC: gcc-12,
@@ -86,6 +92,15 @@ jobs:
               lib: "",
               testRegex: "python",
             }
+          - {
+            name: "Gcc-12-Python-Debug",
+            container: "ikarusproject/ikarus-dev-gcc:latest",
+            config: Debug,
+            compilerC: gcc-12,
+            compilerCxx: g++-12,
+            lib: "",
+            testRegex: "python",
+          }
     container:
       image: ${{ matrix.config.container }}
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
@@ -96,6 +111,7 @@ jobs:
       - name: Build
         working-directory: ./repo
         run: |
+          export IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE=${{ matrix.config.config }}
           mkdir cmake-build-${{ matrix.config.config }}
           cd cmake-build-${{ matrix.config.config }}
           cmake ../  -DCMAKE_BUILD_TYPE=${{ matrix.config.config }} -GNinja -DCMAKE_C_COMPILER=${{ matrix.config.compilerC }} -DCMAKE_CXX_COMPILER=${{ matrix.config.compilerCxx }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 env:
-  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: 'Release'
+  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: "Release"
 
 jobs:
   Build:
@@ -39,7 +39,7 @@ jobs:
               compilerC: clang-16,
               compilerCxx: clang++-16,
               lib: "-stdlib=libc++",
-              testRegex: "cpp_quick"
+              testRegex: "cpp_quick",
             }
           - {
               name: "Clang-16-Release",
@@ -48,7 +48,7 @@ jobs:
               compilerC: clang-16,
               compilerCxx: clang++-16,
               lib: "-stdlib=libc++",
-              testRegex: "cpp"
+              testRegex: "cpp",
             }
           - {
               name: "Clang-16-Python",
@@ -57,7 +57,7 @@ jobs:
               compilerC: clang-16,
               compilerCxx: clang++-16,
               lib: "-stdlib=libc++",
-              testRegex: "python"
+              testRegex: "python",
             }
           - {
               name: "Gcc-12-Debug",
@@ -66,7 +66,7 @@ jobs:
               compilerC: gcc-12,
               compilerCxx: g++-12,
               lib: "",
-              testRegex: "cpp_quick"
+              testRegex: "cpp_quick",
             }
           - {
               name: "Gcc-12-Release",
@@ -75,7 +75,7 @@ jobs:
               compilerC: gcc-12,
               compilerCxx: g++-12,
               lib: "",
-              testRegex: "cpp"
+              testRegex: "cpp",
             }
           - {
               name: "Gcc-12-Python",
@@ -84,7 +84,7 @@ jobs:
               compilerC: gcc-12,
               compilerCxx: g++-12,
               lib: "",
-              testRegex: "python"
+              testRegex: "python",
             }
     container:
       image: ${{ matrix.config.container }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -21,6 +21,9 @@ on:
       - "**.md"
   workflow_dispatch:
 
+env:
+  IKARUS_PYTHON_TEST_BUILD_TYPE: 'Release'
+
 jobs:
   Build-Clang:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -26,7 +26,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container:
-      image: henrij22/ikarus-dev-clang:latest
+      image: ikarusproject/ikarus-dev-clang:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     strategy:
       fail-fast: false
@@ -77,7 +77,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container:
-      image: ikarusproject/ikarus-dev:latest
+      image: ikarusproject/ikarus-dev-gcc:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     strategy:
       fail-fast: false

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -49,7 +49,7 @@ jobs:
               testRegex: "cpp",
             }
           - {
-            name: "Clang-12-Python",
+            name: "Clang-16-Python",
             config: Release,
             compilerC: clang-16,
             compilerCxx: clang++-16,

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -120,4 +120,4 @@ jobs:
           cmake --build . --parallel 2 --target build_${{ matrix.config.testRegex }}_tests
       - name: Tests
         working-directory: ./repo/cmake-build-${{ matrix.config.config }}
-        run: ctest --output-on-failure --parallel 2 -L ${{ matrix.config.testRegex }}
+        run: ctest --verbose --parallel 2 -L ${{ matrix.config.testRegex }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -121,4 +121,4 @@ jobs:
           cmake --build . --parallel 2 --target build_${{ matrix.config.testRegex }}_tests
       - name: Tests
         working-directory: ./repo/cmake-build-${{ matrix.config.config }}
-        run: ctest --verbose --parallel 2 -L ${{ matrix.config.testRegex }}
+        run: ctest --output-on-failure --parallel 2 -L ${{ matrix.config.testRegex }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -104,6 +104,8 @@ jobs:
     container:
       image: ${{ matrix.config.container }}
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
+    env:
+      IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: ${{ matrix.config.config }} 
     steps:
       - uses: actions/checkout@v4
         with:
@@ -111,7 +113,6 @@ jobs:
       - name: Build
         working-directory: ./repo
         run: |
-          export IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE=${{ matrix.config.config }}
           mkdir cmake-build-${{ matrix.config.config }}
           cd cmake-build-${{ matrix.config.config }}
           cmake ../  -DCMAKE_BUILD_TYPE=${{ matrix.config.config }} -GNinja -DCMAKE_C_COMPILER=${{ matrix.config.compilerC }} -DCMAKE_CXX_COMPILER=${{ matrix.config.compilerCxx }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -26,7 +26,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container:
-      image: henrij22/dunebase-clang:latest
+      image: henrij22/ikarus-dev-clang:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
     strategy:
       fail-fast: false

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -21,6 +21,9 @@ on:
       - "**.md"
   workflow_dispatch:
 
+env:
+  IKARUS_PYTHON_TEST_BUILD_TYPE: 'Release'
+
 jobs:
   build-n-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -25,7 +25,7 @@ jobs:
   build-n-test:
     runs-on: ubuntu-latest
     container:
-      image: ikarusproject/ikarus-dev:latest
+      image: henrij22/ikarus-dev-clang:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
 
     steps:

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 env:
-  IKARUS_PYTHON_TEST_BUILD_TYPE: 'Release'
+  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: 'Release'
 
 jobs:
   build-n-test:

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -25,7 +25,7 @@ jobs:
   build-n-test:
     runs-on: ubuntu-latest
     container:
-      image: henrij22/ikarus-dev-clang:latest
+      image: ikarusproject/ikarus-dev-clang:latest
       options: --memory-swap="20g" --memory="20g" --cpus="2" --user root
 
     steps:

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install package from tarball
         run: |
-          pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
+          CMAKE_FLAGS=$DUNE_CMAKE_FLAGS pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
 
       - name: Copy test files to pytests folder
         run: |

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install package from tarball
         run: |
-          CMAKE_FLAGS=$DUNE_CMAKE_FLAGS pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
+          CMAKE_FLAGS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++" pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
 
       - name: Copy test files to pytests folder
         run: |

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install package from tarball
         run: |
-          CMAKE_FLAGS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++" pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
+          CMAKE_FLAGS=DUNE_CMAKE_FLAGS pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
 
       - name: Copy test files to pytests folder
         run: |

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install package from tarball
         run: |
-          CMAKE_FLAGS=DUNE_CMAKE_FLAGS pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
+          pip install dist/pyikarus-$version.tar.gz --verbose --upgrade --no-build-isolation
 
       - name: Copy test files to pytests folder
         run: |

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 env:
-  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: 'Release'
+  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: "Release"
 
 jobs:
   build-n-test:

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 env:
-  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: "Release"
+  IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE: "Debug"
 
 jobs:
   build-n-test:

--- a/ikarus/python/test/debug_info.py
+++ b/ikarus/python/test/debug_info.py
@@ -1,15 +1,24 @@
 # SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
+import dune.generator as generator
+
 
 os.environ["DUNE_LOG_LEVEL"] = "debug"
 os.environ["DUNE_SAVE_BUILD"] = "terminal"
 
 
 def setDebugFlags():
-    import dune.generator as generator
+    def apply_debug_flags():
+        generator.setFlags("-g ", noChecks=False)
 
-    generator.setFlags("-g ", noChecks=False)
+    # Check if the environment variable is set
+    build_type = os.environ.get("IKARUS_PYTHON_TEST_BUILD_TYPE")
+
+    # Apply flags only if the build type is Debug, or if the variable is not set
+    if build_type == "Debug" or build_type is None:
+        apply_debug_flags()
+        print("Python Generator: Debug Flag enabled")
 
 
 def unsetDebugFlags():

--- a/ikarus/python/test/debug_info.py
+++ b/ikarus/python/test/debug_info.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
 import dune.generator as generator
-
+from logging import info
 
 os.environ["DUNE_LOG_LEVEL"] = "debug"
 os.environ["DUNE_SAVE_BUILD"] = "terminal"
@@ -18,7 +18,9 @@ def setDebugFlags():
     # Apply flags only if the build type is Debug, or if the variable is not set
     if build_type == "Debug" or build_type is None:
         apply_debug_flags()
-        print("Python Generator: Debug Flag enabled")
+        info("JIT Python Bindings BUILD_TYPE: Debug")
+    else:
+        info("JIT Python Bindings BUILD_TYPE: Release")
 
 
 def unsetDebugFlags():

--- a/ikarus/python/test/debug_info.py
+++ b/ikarus/python/test/debug_info.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
 import dune.generator as generator
-from logging import warn
+from logging import info
 
 os.environ["DUNE_LOG_LEVEL"] = "debug"
 os.environ["DUNE_SAVE_BUILD"] = "terminal"
@@ -18,9 +18,9 @@ def setDebugFlags():
     # Apply flags only if the build type is Debug, or if the variable is not set
     if build_type == "Debug" or build_type is None:
         apply_debug_flags()
-        warn("JIT Python Bindings BUILD_TYPE: Debug")
+        info("JIT Python Bindings BUILD_TYPE: Debug")
     else:
-        warn("JIT Python Bindings BUILD_TYPE: Release")
+        info("JIT Python Bindings BUILD_TYPE: Release")
 
 
 def unsetDebugFlags():

--- a/ikarus/python/test/debug_info.py
+++ b/ikarus/python/test/debug_info.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
 import dune.generator as generator
-from logging import debug
+from logging import warn
 
 os.environ["DUNE_LOG_LEVEL"] = "debug"
 os.environ["DUNE_SAVE_BUILD"] = "terminal"
@@ -18,9 +18,9 @@ def setDebugFlags():
     # Apply flags only if the build type is Debug, or if the variable is not set
     if build_type == "Debug" or build_type is None:
         apply_debug_flags()
-        debug("JIT Python Bindings BUILD_TYPE: Debug")
+        warn("JIT Python Bindings BUILD_TYPE: Debug")
     else:
-        debug("JIT Python Bindings BUILD_TYPE: Release")
+        warn("JIT Python Bindings BUILD_TYPE: Release")
 
 
 def unsetDebugFlags():

--- a/ikarus/python/test/debug_info.py
+++ b/ikarus/python/test/debug_info.py
@@ -13,7 +13,7 @@ def setDebugFlags():
         generator.setFlags("-g ", noChecks=False)
 
     # Check if the environment variable is set
-    build_type = os.environ.get("IKARUS_PYTHON_TEST_BUILD_TYPE")
+    build_type = os.environ.get("IKARUS_PYTHON_TEST_BUILD_TYPE_OVERRIDE")
 
     # Apply flags only if the build type is Debug, or if the variable is not set
     if build_type == "Debug" or build_type is None:

--- a/ikarus/python/test/debug_info.py
+++ b/ikarus/python/test/debug_info.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 import os
 import dune.generator as generator
-from logging import info
+from logging import debug
 
 os.environ["DUNE_LOG_LEVEL"] = "debug"
 os.environ["DUNE_SAVE_BUILD"] = "terminal"
@@ -18,9 +18,9 @@ def setDebugFlags():
     # Apply flags only if the build type is Debug, or if the variable is not set
     if build_type == "Debug" or build_type is None:
         apply_debug_flags()
-        info("JIT Python Bindings BUILD_TYPE: Debug")
+        debug("JIT Python Bindings BUILD_TYPE: Debug")
     else:
-        info("JIT Python Bindings BUILD_TYPE: Release")
+        debug("JIT Python Bindings BUILD_TYPE: Release")
 
 
 def unsetDebugFlags():

--- a/ikarus/python/test/nonlinearelastictest.py
+++ b/ikarus/python/test/nonlinearelastictest.py
@@ -5,6 +5,9 @@ import debug_info
 
 debug_info.setDebugFlags()
 
+from dune.common import FieldVector
+FieldVector([2,2])
+
 import ikarus as iks
 from ikarus import finite_elements, utils, assembler
 import numpy as np

--- a/ikarus/python/test/nonlinearelastictest.py
+++ b/ikarus/python/test/nonlinearelastictest.py
@@ -5,9 +5,6 @@ import debug_info
 
 debug_info.setDebugFlags()
 
-from dune.common import FieldVector
-FieldVector([2,2])
-
 import ikarus as iks
 from ikarus import finite_elements, utils, assembler
 import numpy as np

--- a/python/ikarus/CMakeLists.txt
+++ b/python/ikarus/CMakeLists.txt
@@ -12,7 +12,7 @@ dune_add_pybind11_module(NAME _ikarus)
 
 set_property(
   TARGET _ikarus
-  PROPERTY LINK_LIBRARIES dunecommon ikarus _io
+  PROPERTY LINK_LIBRARIES dunecommon ikarus 
   APPEND
 )
 

--- a/python/ikarus/CMakeLists.txt
+++ b/python/ikarus/CMakeLists.txt
@@ -15,6 +15,7 @@ set_property(
   PROPERTY LINK_LIBRARIES dunecommon ikarus 
   APPEND
 )
+add_dependencies(_ikarus _io)
 
 if(SKBUILD)
   install(TARGETS _ikarus LIBRARY DESTINATION python/ikarus)

--- a/python/ikarus/CMakeLists.txt
+++ b/python/ikarus/CMakeLists.txt
@@ -12,7 +12,7 @@ dune_add_pybind11_module(NAME _ikarus)
 
 set_property(
   TARGET _ikarus
-  PROPERTY LINK_LIBRARIES dunecommon ikarus 
+  PROPERTY LINK_LIBRARIES dunecommon ikarus
   APPEND
 )
 add_dependencies(_ikarus _io)


### PR DESCRIPTION
There are two points that need to be adressed in the docker container for this to work
1. 
https://github.com/henrij22/ikarus-docker-container/blob/5fe56de3ec7f26a2ee50470d0b6140ad6a7779d4/DuneBase/Dockerfile#L18 
`ENV DUNE_CMAKE_FLAGS=-DCMAKE_C_COMPILER=${ccompiler} -DCMAKE_CXX_COMPILER=${cppcompiler}` has to be set. That tells the dune-py environment which compiler to use 

2. the dune modules have to be compiled with the same compiler as ikarus 
this can be enforced by setting 
https://github.com/henrij22/ikarus-docker-container/blob/5fe56de3ec7f26a2ee50470d0b6140ad6a7779d4/DevelopContainer/Dockerfile#L2
`ARG compiler "gcc"` 


Currently our container always use the gcc version (see ARG COMPILER="gcc" and https://github.com/ikarus-project/ikarus-docker-container/blob/54a36ff1319960b1af165695927d65fdd6586c80/.github/workflows/build_docker_image_debian.yml#L21 in the action) 
