### PR TITLE
Bump  dune version to 2.11 in python requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from skbuild import setup
 # /dune/dune-common/build-cmake/run-in-dune-env python -m twine upload dist/* --verbose
 
 ikarusVersion = "0.4.1"
-duneVersion = "2.10.0"
+duneVersion = "2.11.0"
 
 metadata = metaData(duneVersion)[1]
 metadata["version"] = ikarusVersion


### PR DESCRIPTION
This bumps the maximum dune versions to be used for the python package to dune 2.11.0.
This got neccesary because of the latest dune vesion bump as the required packages couldn't be installed anymore and the python Package Test would always fail