### PR TITLE
[WIP] Add functionality to have user-specific convergence criteria for nonlinear solvers

### DIFF
--- a/ikarus/finiteelements/mechanics/materials/vanishingstress.hh
+++ b/ikarus/finiteelements/mechanics/materials/vanishingstress.hh
@@ -190,7 +190,7 @@ private:
 
     int minIter = isAutoDiff ? 1 : 0;
     // THE CTAD is broken for designated initializers in clang 16, when we drop support this can be simplified
-    NewtonRaphsonConfig<decltype(linearSolver), decltype(updateFunction)> nrs{
+    NewtonRaphsonConfig<ConvergenceCriterion::ResiduumNorm, decltype(linearSolver), decltype(updateFunction)> nrs{
         .parameters     = {.tol = tol_, .maxIter = 100, .minIter = minIter},
         .linearSolver   = linearSolver,
         .updateFunction = updateFunction

--- a/ikarus/solver/nonlinearsolver/CMakeLists.txt
+++ b/ikarus/solver/nonlinearsolver/CMakeLists.txt
@@ -3,6 +3,6 @@
 
 # install headers
 install(FILES newtonraphson.hh trustregion.hh newtonraphsonwithscalarsubsidiaryfunction.hh
-              nonlinearsolverfactory.hh solverinfos.hh
+              nonlinearsolverfactory.hh solverinfos.hh convergencecriteria.hh
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ikarus/solver/nonlinearsolver
 )

--- a/ikarus/solver/nonlinearsolver/convergencecriteria.hh
+++ b/ikarus/solver/nonlinearsolver/convergencecriteria.hh
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2021-2024 The Ikarus Developers mueller@ibb.uni-stuttgart.de
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+/**
+ * \file convergencecriteria.hh
+ * \brief A collection of convergence criteria used by the nonlinear solvers.
+ */
+
+#include <dune/common/float_cmp.hh>
+
+#include <ikarus/utils/linearalgebrahelper.hh>
+
+#pragma once
+
+namespace Ikarus::ConvergenceCriteria {
+
+struct ResiduumNorm
+{
+  ResiduumNorm() = default;
+  /**
+   * \brief Call operator when the norm of the residuum is chosen as the convergence criteria.
+   * \tparam NLO Type of the nonlinear operator.
+   * \tparam SS Type of the nonlinear solver settings.
+   * \tparam CV Type of the correction vector used to update the solution.
+   * \param nonLinearOperator The nonlinear operator.
+   * \param solverSettings The nonlinear solver settings.
+   * \param corectionVector The correction vector used to update the solution.
+   */
+  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
+  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
+                  [[maybe_unused]] const CV& correctionVector) const {
+    const auto& rx = nonLinearOperator.value();
+    auto rNorm     = norm(rx);
+    return Dune::FloatCmp::le(static_cast<double>(rNorm), solverSettings.tol);
+  }
+};
+
+struct CorrectionNorm
+{
+  CorrectionNorm() = default;
+  /**
+   * \brief Call operator when the norm of the correction vector is chosen as the convergence criteria.
+   * \tparam NLO Type of the nonlinear operator.
+   * \tparam SS Type of the nonlinear solver settings.
+   * \tparam CV Type of the correction vector used to update the solution.
+   * \param nonLinearOperator The nonlinear operator.
+   * \param solverSettings The nonlinear solver settings.
+   * \param corectionVector The correction vector used to update the solution.
+   */
+  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
+  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
+                  [[maybe_unused]] const CV& correctionVector) const {
+    auto dNorm = norm(correctionVector);
+    return Dune::FloatCmp::le(static_cast<double>(dNorm), solverSettings.tol);
+  }
+};
+
+struct MaximumSolution
+{
+  /**
+   * \brief Constructor for MaximumSolution.
+   * \param maxSol The expected maximum value of the solution vector.
+   */
+  explicit MaximumSolution(double maxSol)
+      : maxSol_{maxSol} {};
+  /**
+   * \brief Call operator when the maximum value of the solution vector is chosen as the convergence criteria.
+   * \tparam NLO Type of the nonlinear operator.
+   * \tparam SS Type of the nonlinear solver settings.
+   * \tparam CV Type of the correction vector used to update the solution.
+   * \param nonLinearOperator The nonlinear operator.
+   * \param solverSettings The nonlinear solver settings.
+   * \param corectionVector The correction vector used to update the solution.
+   */
+  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
+  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
+                  [[maybe_unused]] const CV& correctionVector) const {
+    const auto& sol = nonLinearOperator.firstParameter();
+    auto maxSol     = max(sol);
+    return Dune::FloatCmp::le(static_cast<double>(std::abs(maxSol - maxSol_)), solverSettings.tol);
+  }
+
+private:
+  double maxSol_;
+};
+
+} // namespace Ikarus::ConvergenceCriteria

--- a/ikarus/solver/nonlinearsolver/convergencecriteria.hh
+++ b/ikarus/solver/nonlinearsolver/convergencecriteria.hh
@@ -26,10 +26,12 @@ struct ResiduumNorm
    * \param solverSettings The nonlinear solver settings.
    * \param corectionVector The correction vector used to update the solution.
    */
-  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
-  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
+  template <typename NLO, typename NSS, typename CV>
+  bool operator()(const std::shared_ptr<NLO>& nonLinearOperator, const NSS& solverSettings,
                   [[maybe_unused]] const CV& correctionVector) const {
-    const auto& rx = nonLinearOperator.value();
+    static_assert(std::is_same_v<CV, std::remove_cvref_t<decltype(nonLinearOperator->firstParameter())>>,
+                  "CV type does not match nonLinearOperator->firstParameter()");
+    const auto& rx = nonLinearOperator->value();
     auto rNorm     = norm(rx);
     return Dune::FloatCmp::le(static_cast<double>(rNorm), solverSettings.tol);
   }
@@ -47,9 +49,11 @@ struct CorrectionNorm
    * \param solverSettings The nonlinear solver settings.
    * \param corectionVector The correction vector used to update the solution.
    */
-  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
-  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
+  template <typename NLO, typename NSS, typename CV>
+  bool operator()(const std::shared_ptr<NLO>& nonLinearOperator, const NSS& solverSettings,
                   [[maybe_unused]] const CV& correctionVector) const {
+    static_assert(std::is_same_v<CV, std::remove_cvref_t<decltype(nonLinearOperator->firstParameter())>>,
+                  "CV type does not match nonLinearOperator->firstParameter()");
     auto dNorm = norm(correctionVector);
     return Dune::FloatCmp::le(static_cast<double>(dNorm), solverSettings.tol);
   }
@@ -72,10 +76,12 @@ struct MaximumSolution
    * \param solverSettings The nonlinear solver settings.
    * \param corectionVector The correction vector used to update the solution.
    */
-  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
-  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
+  template <typename NLO, typename NSS, typename CV>
+  bool operator()(const std::shared_ptr<NLO>& nonLinearOperator, const NSS& solverSettings,
                   [[maybe_unused]] const CV& correctionVector) const {
-    const auto& sol = nonLinearOperator.firstParameter();
+    static_assert(std::is_same_v<CV, std::remove_cvref_t<decltype(nonLinearOperator->firstParameter())>>,
+                  "CV type does not match nonLinearOperator->firstParameter()");
+    const auto& sol = nonLinearOperator->firstParameter();
     auto maxSol     = max(sol);
     return Dune::FloatCmp::le(static_cast<double>(std::abs(maxSol - maxSol_)), solverSettings.tol);
   }

--- a/ikarus/solver/nonlinearsolver/convergencecriteria.hh
+++ b/ikarus/solver/nonlinearsolver/convergencecriteria.hh
@@ -26,12 +26,10 @@ struct ResiduumNorm
    * \param solverSettings The nonlinear solver settings.
    * \param corectionVector The correction vector used to update the solution.
    */
-  template <typename NLO, typename NSS, typename CV>
-  bool operator()(const std::shared_ptr<NLO>& nonLinearOperator, const NSS& solverSettings,
+  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
+  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
                   [[maybe_unused]] const CV& correctionVector) const {
-    static_assert(std::is_same_v<CV, std::remove_cvref_t<decltype(nonLinearOperator->firstParameter())>>,
-                  "CV type does not match nonLinearOperator->firstParameter()");
-    const auto& rx = nonLinearOperator->value();
+    const auto& rx = nonLinearOperator.value();
     auto rNorm     = norm(rx);
     return Dune::FloatCmp::le(static_cast<double>(rNorm), solverSettings.tol);
   }
@@ -49,11 +47,9 @@ struct CorrectionNorm
    * \param solverSettings The nonlinear solver settings.
    * \param corectionVector The correction vector used to update the solution.
    */
-  template <typename NLO, typename NSS, typename CV>
-  bool operator()(const std::shared_ptr<NLO>& nonLinearOperator, const NSS& solverSettings,
+  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
+  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
                   [[maybe_unused]] const CV& correctionVector) const {
-    static_assert(std::is_same_v<CV, std::remove_cvref_t<decltype(nonLinearOperator->firstParameter())>>,
-                  "CV type does not match nonLinearOperator->firstParameter()");
     auto dNorm = norm(correctionVector);
     return Dune::FloatCmp::le(static_cast<double>(dNorm), solverSettings.tol);
   }
@@ -76,12 +72,10 @@ struct MaximumSolution
    * \param solverSettings The nonlinear solver settings.
    * \param corectionVector The correction vector used to update the solution.
    */
-  template <typename NLO, typename NSS, typename CV>
-  bool operator()(const std::shared_ptr<NLO>& nonLinearOperator, const NSS& solverSettings,
+  template <typename NLO, typename NSS, typename CV = std::remove_cvref_t<decltype(NLO::firstParameter())>>
+  bool operator()(NLO& nonLinearOperator, const NSS& solverSettings,
                   [[maybe_unused]] const CV& correctionVector) const {
-    static_assert(std::is_same_v<CV, std::remove_cvref_t<decltype(nonLinearOperator->firstParameter())>>,
-                  "CV type does not match nonLinearOperator->firstParameter()");
-    const auto& sol = nonLinearOperator->firstParameter();
+    const auto& sol = nonLinearOperator.firstParameter();
     auto maxSol     = max(sol);
     return Dune::FloatCmp::le(static_cast<double>(std::abs(maxSol - maxSol_)), solverSettings.tol);
   }

--- a/ikarus/solver/nonlinearsolver/convergencecriteria.hh
+++ b/ikarus/solver/nonlinearsolver/convergencecriteria.hh
@@ -9,74 +9,128 @@
 #include <dune/common/float_cmp.hh>
 
 #include <ikarus/controlroutines/pathfollowingfunctions.hh>
+#include <ikarus/utils/defaultfunctions.hh>
 #include <ikarus/utils/linearalgebrahelper.hh>
+#include <ikarus/utils/makeenum.hh>
 
 #pragma once
 
-namespace Ikarus::ConvergenceCriteria {
+namespace Ikarus {
 
-struct ResiduumNorm
+/**
+ * \enum PreConditioner
+ * \brief Enumeration of available preconditioners for the trust region solver.
+ */
+enum class PreConditioner
 {
-  /**
-   * \brief Call operator when the norm of the residuum is chosen as the convergence criteria.
-   * \tparam NLO Type of the nonlinear operator.
-   * \tparam SS Type of the nonlinear solver settings.
-   * \tparam CV Type of the correction vector used to update the solution.
-   * \param nonLinearOperator The nonlinear operator.
-   * \param solverSettings The nonlinear solver settings.
-   * \param corectionVector The correction vector used to update the solution.
-   * \param subsidiaryArgs The subsidiary arguments used with \ref NewtonRaphsonWithSubsidiaryFunction (optional with
-   * its value (f=0))
-   */
+  IncompleteCholesky,
+  IdentityPreconditioner,
+  DiagonalPreconditioner
+};
+
+MAKE_ENUM(ConvergenceCriterion, ResiduumNorm, CorrectionNorm, MaximumOfCorrectionVector);
+
+template <typename NLO, ConvergenceCriterion CC = ConvergenceCriterion::ResiduumNorm,
+          typename LS = utils::SolverDefault, typename UF = utils::UpdateDefault>
+class NewtonRaphson;
+
+template <typename NLO, ConvergenceCriterion CC = ConvergenceCriterion::ResiduumNorm,
+          typename LS = utils::SolverDefault, typename UF = utils::UpdateDefault>
+class NewtonRaphsonWithSubsidiaryFunction;
+
+template <typename NLO, PreConditioner preConditioner = PreConditioner::IncompleteCholesky,
+          typename UF = utils::UpdateDefault>
+class TrustRegion;
+
+template <ConvergenceCriterion CC>
+requires(CC != ConvergenceCriterion::BEGIN and CC != ConvergenceCriterion::END)
+struct NRConvergenceCriteria
+{
   template <typename NLO, typename NSS, typename CV>
-  bool operator()(const NLO& nonLinearOperator, const NSS& solverSettings, const CV& correctionVector,
-                  const SubsidiaryArgs& subsidiaryArgs = {.f = 0.0}) {
-    const auto& rx = nonLinearOperator.value();
-    auto rNorm     = sqrt(rx.dot(rx) + subsidiaryArgs.f * subsidiaryArgs.f);
-    return Dune::FloatCmp::le(static_cast<double>(rNorm), solverSettings.tol);
+  bool operator()(const NLO& nonLinearOperator, const NSS& solverSettings, const CV& correctionVector) {
+    if constexpr (CC == ConvergenceCriterion::ResiduumNorm) {
+      const auto& rx = nonLinearOperator.value();
+      auto rNorm     = norm(rx);
+      return Dune::FloatCmp::le(static_cast<double>(rNorm), solverSettings.tol);
+    } else if constexpr (CC == ConvergenceCriterion::CorrectionNorm) {
+      auto dNorm = norm(correctionVector);
+      return Dune::FloatCmp::le(static_cast<double>(dNorm), solverSettings.tol);
+    } else if constexpr (CC == ConvergenceCriterion::MaximumOfCorrectionVector) {
+      auto maxCorr = max(correctionVector);
+      return Dune::FloatCmp::le(static_cast<double>(maxCorr), solverSettings.tol);
+    } else {
+      return false; // TODO Change to Dune::AlwaysFalse
+    }
   }
 };
 
-struct CorrectionNorm
+template <ConvergenceCriterion CC>
+requires(CC != ConvergenceCriterion::BEGIN and CC != ConvergenceCriterion::END)
+struct NRWSFConvergenceCriteria
 {
-  /**
-   * \brief Call operator when the norm of the correction vector is chosen as the convergence criteria.
-   * \tparam NLO Type of the nonlinear operator.
-   * \tparam SS Type of the nonlinear solver settings.
-   * \tparam CV Type of the correction vector used to update the solution.
-   * \param nonLinearOperator The nonlinear operator.
-   * \param solverSettings The nonlinear solver settings.
-   * \param corectionVector The correction vector used to update the solution.
-   * \param subsidiaryArgs The subsidiary arguments used with \ref NewtonRaphsonWithSubsidiaryFunction (optional with
-   * its value (f=0))
-   */
-  template <typename NLO, typename NSS, typename CV>
-  bool operator()(const NLO& nonLinearOperator, const NSS& solverSettings, const CV& correctionVector,
-                  const SubsidiaryArgs& subsidiaryArgs = {.f = 0.0}) {
-    auto dNorm = norm(correctionVector);
-    return Dune::FloatCmp::le(static_cast<double>(dNorm), solverSettings.tol);
+  template <typename NLO, typename NSS, typename DD>
+  bool operator()(const NLO& nonLinearOperator, const NSS& solverSettings, const DD& deltaD, double deltaLambda,
+                  const SubsidiaryArgs& subsidiaryArgs) {
+    if constexpr (CC == ConvergenceCriterion::ResiduumNorm) {
+      const auto& rx = nonLinearOperator.value();
+      Eigen::VectorXd totalResidual(rx.size() + 1);
+      totalResidual << rx, subsidiaryArgs.f;
+      auto rNorm = norm(totalResidual);
+      return Dune::FloatCmp::le(static_cast<double>(rNorm), solverSettings.tol);
+    } else if constexpr (CC == ConvergenceCriterion::CorrectionNorm) {
+      Eigen::VectorXd correctionVector(deltaD.size() + 1);
+      correctionVector << deltaD, deltaLambda;
+      auto dNorm = norm(correctionVector);
+      return Dune::FloatCmp::le(static_cast<double>(dNorm), solverSettings.tol);
+    } else if constexpr (CC == ConvergenceCriterion::MaximumOfCorrectionVector) {
+      Eigen::VectorXd correctionVector(deltaD.size() + 1);
+      correctionVector << deltaD, deltaLambda;
+      auto maxCorr = max(correctionVector);
+      return Dune::FloatCmp::le(static_cast<double>(maxCorr), solverSettings.tol);
+    } else {
+      return false; // TODO Change to Dune::AlwaysFalse
+    }
   }
 };
 
-struct MaximumCorrection
+template <ConvergenceCriterion CC>
+requires(CC != ConvergenceCriterion::BEGIN and CC != ConvergenceCriterion::END)
+struct TRConvergenceCriteria
 {
-  /**
-   * \brief Call operator when the maximum value of the correction vector is chosen as the convergence criteria.
-   * \tparam NLO Type of the nonlinear operator.
-   * \tparam SS Type of the nonlinear solver settings.
-   * \tparam CV Type of the correction vector used to update the solution.
-   * \param nonLinearOperator The nonlinear operator.
-   * \param solverSettings The nonlinear solver settings.
-   * \param corectionVector The correction vector used to update the solution.
-   * \param subsidiaryArgs The subsidiary arguments used with \ref NewtonRaphsonWithSubsidiaryFunction (optional with
-   * its value (f=0))
-   */
   template <typename NLO, typename NSS, typename CV>
-  bool operator()(const NLO& nonLinearOperator, const NSS& solverSettings, const CV& correctionVector,
-                  const SubsidiaryArgs& subsidiaryArgs = {.f = 0.0}) {
-    auto maxCorr = max(correctionVector);
-    return Dune::FloatCmp::le(static_cast<double>(maxCorr), solverSettings.tol);
+  bool operator()(const NLO& nonLinearOperator, const NSS& solverSettings, const CV& correctionVector) {
+    if constexpr (CC == ConvergenceCriterion::ResiduumNorm) {
+      return false;
+    } else if constexpr (CC == ConvergenceCriterion::CorrectionNorm) {
+      return false;
+    } else if constexpr (CC == ConvergenceCriterion::MaximumOfCorrectionVector) {
+      return false;
+    } else {
+      return false; // TODO Change to Dune::AlwaysFalse
+    }
   }
 };
 
-} // namespace Ikarus::ConvergenceCriteria
+template <typename NLS, ConvergenceCriterion CC>
+struct ConvergenceCriteria
+{
+  using NR    = NewtonRaphson<typename NLS::NonLinearOperator, NLS::criteraType, typename NLS::LinearSolverType,
+                              typename NLS::UpdateFunctionType>;
+  using NRWSF = NewtonRaphsonWithSubsidiaryFunction<typename NLS::NonLinearOperator, NLS::criteraType,
+                                                    typename NLS::LinearSolverType, typename NLS::UpdateFunctionType>;
+  using TR    = TrustRegion<typename NLS::NonLinearOperator>;
+
+  using Criteria = std::conditional_t<
+      std::is_same_v<NLS, NR>, NRConvergenceCriteria<CC>,
+      std::conditional_t<std::is_same_v<NLS, NRWSF>, NRWSFConvergenceCriteria<CC>, TRConvergenceCriteria<CC>>>;
+
+  template <typename... Args>
+  bool operator()(Args&&... args) {
+    return criteria(std::forward<Args>(args)...);
+  }
+
+private:
+  Criteria criteria{};
+};
+
+} // namespace Ikarus

--- a/ikarus/solver/nonlinearsolver/newtonraphson.hh
+++ b/ikarus/solver/nonlinearsolver/newtonraphson.hh
@@ -181,7 +181,8 @@ public:
     int iter{0};
     if constexpr (isLinearSolver)
       linearSolver_.analyzePattern(Ax);
-    while ((not(convergenceCriterion_(nonLinearOperator(), settings_, correction_)) && iter < settings_.maxIter) or
+    while ((not(convergenceCriterion_(std::make_shared<NLO>(nonLinearOperator()), settings_, correction_)) &&
+            iter < settings_.maxIter) or
            iter < settings_.minIter) {
       this->notify(NonLinearSolverMessages::ITERATION_STARTED);
       if constexpr (isLinearSolver) {

--- a/ikarus/solver/nonlinearsolver/newtonraphson.hh
+++ b/ikarus/solver/nonlinearsolver/newtonraphson.hh
@@ -181,8 +181,7 @@ public:
     int iter{0};
     if constexpr (isLinearSolver)
       linearSolver_.analyzePattern(Ax);
-    while ((not(convergenceCriterion_(std::make_shared<NLO>(nonLinearOperator()), settings_, correction_)) &&
-            iter < settings_.maxIter) or
+    while ((not(convergenceCriterion_(nonLinearOperator(), settings_, correction_)) && iter < settings_.maxIter) or
            iter < settings_.minIter) {
       this->notify(NonLinearSolverMessages::ITERATION_STARTED);
       if constexpr (isLinearSolver) {

--- a/ikarus/solver/nonlinearsolver/newtonraphsonwithscalarsubsidiaryfunction.hh
+++ b/ikarus/solver/nonlinearsolver/newtonraphsonwithscalarsubsidiaryfunction.hh
@@ -211,8 +211,7 @@ public:
       linearSolver_.analyzePattern(Ax);
 
     /// Iterative solving scheme
-    while (not(convergenceCriterion_(std::make_shared<NLO>(nonLinearOperator()), settings_, deltaD)) &&
-           iter < settings_.maxIter) {
+    while (not(convergenceCriterion_(nonLinearOperator(), settings_, deltaD)) && iter < settings_.maxIter) {
       this->notify(NonLinearSolverMessages::ITERATION_STARTED);
 
       /// Two-step solving procedure

--- a/ikarus/solver/nonlinearsolver/newtonraphsonwithscalarsubsidiaryfunction.hh
+++ b/ikarus/solver/nonlinearsolver/newtonraphsonwithscalarsubsidiaryfunction.hh
@@ -211,7 +211,8 @@ public:
       linearSolver_.analyzePattern(Ax);
 
     /// Iterative solving scheme
-    while (not(convergenceCriterion_(nonLinearOperator(), settings_, deltaD)) && iter < settings_.maxIter) {
+    while (not(convergenceCriterion_(std::make_shared<NLO>(nonLinearOperator()), settings_, deltaD)) &&
+           iter < settings_.maxIter) {
       this->notify(NonLinearSolverMessages::ITERATION_STARTED);
 
       /// Two-step solving procedure

--- a/ikarus/solver/nonlinearsolver/trustregion.hh
+++ b/ikarus/solver/nonlinearsolver/trustregion.hh
@@ -27,17 +27,6 @@
 
 namespace Ikarus {
 
-/**
- * \enum PreConditioner
- * \brief Enumeration of available preconditioners for the trust region solver.
- */
-enum class PreConditioner
-{
-  IncompleteCholesky,
-  IdentityPreconditioner,
-  DiagonalPreconditioner
-};
-
 struct TRSettings
 {
   int verbosity    = 5;                                       ///< Verbosity level.
@@ -77,10 +66,6 @@ struct TrustRegionConfig
     return settings;
   }
 };
-
-template <typename NLO, PreConditioner preConditioner = PreConditioner::IncompleteCholesky,
-          typename UF = utils::UpdateDefault>
-class TrustRegion;
 
 /**
  * \brief Function to create a trust region non-linear solver
@@ -162,18 +147,18 @@ struct Stats
 <a href="https://github.com/NicolasBoumal/manopt/blob/master/manopt/solvers/trustregions/trustregions.m">Manopt</a>.
 * \ingroup solvers
 * \tparam NLO Type of the nonlinear operator to solve.
-* \tparam preConditioner Type of preconditioner to use (default is IncompleteCholesky).
+* \tparam pc Type of preconditioner to use (default is IncompleteCholesky).
 * \tparam UF Type of the update function
 */
-template <typename NLO, PreConditioner preConditioner, typename UF>
+template <typename NLO, PreConditioner pc, typename UF>
 class TrustRegion : public IObservable<NonLinearSolverMessages>
 {
 public:
   using Settings  = TRSettings;                               ///< Type of the settings for the TrustRegion solver
   using ValueType = typename NLO::template ParameterValue<0>; ///< Type of the parameter vector of
                                                               ///< the nonlinear operator
-  using CorrectionType = typename NLO::DerivativeType;        ///< Type of the correction of x += deltaX.
-  using UpdateFunction = UF;                                  ///< Type of the update function.
+  using CorrectionType     = typename NLO::DerivativeType;    ///< Type of the correction of x += deltaX.
+  using UpdateFunctionType = UF;                              ///< Type of the update function.
 
   using NonLinearOperator = NLO; ///< Type of the non-linear operator
 
@@ -181,6 +166,8 @@ public:
                                                                                         ///< cost
 
   using MatrixType = std::remove_cvref_t<typename NLO::template FunctionReturnType<2>>; ///< Type of the Hessian
+
+  static constexpr auto preConditioner = pc;
 
   /**
    * \brief Constructs a TrustRegion solver instance.
@@ -499,7 +486,7 @@ private:
   }
 
   NLO nonLinearOperator_;
-  UpdateFunction updateFunction_;
+  UpdateFunctionType updateFunction_;
   typename NLO::template ParameterValue<0> xOld_;
   CorrectionType eta_;
   CorrectionType Heta_;

--- a/ikarus/solver/nonlinearsolver/trustregion.hh
+++ b/ikarus/solver/nonlinearsolver/trustregion.hh
@@ -17,6 +17,7 @@
 #include <Eigen/Sparse>
 
 #include <ikarus/linearalgebra/truncatedconjugategradient.hh>
+#include <ikarus/solver/nonlinearsolver/convergencecriteria.hh>
 #include <ikarus/solver/nonlinearsolver/solverinfos.hh>
 #include <ikarus/utils/defaultfunctions.hh>
 #include <ikarus/utils/linearalgebrahelper.hh>

--- a/ikarus/utils/linearalgebrahelper.hh
+++ b/ikarus/utils/linearalgebrahelper.hh
@@ -269,6 +269,48 @@ auto norm(const Eigen::MatrixBase<Derived>& v) {
 auto norm(const std::floating_point auto& v) { return std::abs(v); }
 
 /**
+ * \brief Adding free maximum coefficient function to Eigen types.
+ * \ingroup utils
+ * \tparam Derived Type of the input Eigen matrix.
+ * \param v Input Eigen matrix.
+ * \return Maximum coefficient of the matrix.
+ */
+template <typename Derived>
+requires(!std::floating_point<Derived>)
+auto max(const Eigen::MatrixBase<Derived>& v) {
+  return v.maxCoeff();
+}
+
+/**
+ * \brief Helper Free Function to have the same interface as for Eigen Vector Types.
+ * \ingroup utils
+ * \param v Input scalar.
+ * \return The scalar itself.
+ */
+auto max(const std::floating_point auto& v) { return v; }
+
+/**
+ * \brief Adding free minimum coefficient function to Eigen types.
+ * \ingroup utils
+ * \tparam Derived Type of the input Eigen matrix.
+ * \param v Input Eigen matrix.
+ * \return Minimum coefficient of the matrix.
+ */
+template <typename Derived>
+requires(!std::floating_point<Derived>)
+auto min(const Eigen::MatrixBase<Derived>& v) {
+  return v.minCoeff();
+}
+
+/**
+ * \brief Helper Free Function to have the same interface as for Eigen Vector Types.
+ * \ingroup utils
+ * \param v Input scalar.
+ * \return The scalar itself.
+ */
+auto min(const std::floating_point auto& v) { return v; }
+
+/**
  * \brief Eigen::DiagonalMatrix Product Missing in Eigen.
  *  \ingroup utils
  * \tparam Scalar Scalar type.

--- a/ikarus/utils/nonlinearoperator.hh
+++ b/ikarus/utils/nonlinearoperator.hh
@@ -256,7 +256,7 @@ public:
    *
    * \return auto& Reference to the zeroth function value.
    */
-  auto& value()
+  auto& value() const
   requires(sizeof...(DerivativeArgs) > 0)
   {
     return nthDerivative<0>();
@@ -269,7 +269,7 @@ public:
    *
    * \return auto& Reference to the derivative function value.
    */
-  auto& derivative()
+  auto& derivative() const
   requires(sizeof...(DerivativeArgs) > 1)
   {
     return nthDerivative<1>();
@@ -282,7 +282,7 @@ public:
    *
    * \return auto& Reference to the second derivative function value.
    */
-  auto& secondDerivative()
+  auto& secondDerivative() const
   requires(sizeof...(DerivativeArgs) > 2)
   {
     return nthDerivative<2>();
@@ -295,7 +295,7 @@ public:
    * \return auto& Reference to the n-th derivative function value.
    */
   template <int n>
-  auto& nthDerivative()
+  auto& nthDerivative() const
   requires(sizeof...(DerivativeArgs) > n)
   {
     if constexpr (requires { std::get<n>(derivativesEvaluated_).get(); })
@@ -309,13 +309,13 @@ public:
    *
    * \return auto& Reference to the last parameter value.
    */
-  auto& lastParameter() { return nthParameter<sizeof...(ParameterArgs) - 1>(); }
+  auto& lastParameter() const { return nthParameter<sizeof...(ParameterArgs) - 1>(); }
   /**
    * \brief Returns the first parameter value.
    *
    * \return auto& Reference to the first parameter value.
    */
-  auto& firstParameter()
+  auto& firstParameter() const
   requires(sizeof...(ParameterArgs) > 0)
   {
     return nthParameter<0>();
@@ -325,7 +325,7 @@ public:
    *
    * \return auto& Reference to the second parameter value.
    */
-  auto& secondParameter()
+  auto& secondParameter() const
   requires(sizeof...(ParameterArgs) > 1)
   {
     return nthParameter<1>();
@@ -337,7 +337,7 @@ public:
    * \return auto& Reference to the n-th parameter value.
    */
   template <int n>
-  auto& nthParameter()
+  auto& nthParameter() const
   requires(sizeof...(ParameterArgs) >= n)
   {
     return std::get<n>(args_).get();
@@ -350,7 +350,7 @@ public:
    * \return auto The new NonLinearOperator.
    */
   template <int... Derivatives>
-  auto subOperator() {
+  auto subOperator() const {
     auto derivatives = derivatives_;
     auto fs = functions([&derivatives]() -> decltype(auto) { return std::get<Derivatives>(derivatives); }()...);
     Ikarus::NonLinearOperator<Impl::Functions<std::tuple_element_t<Derivatives, decltype(derivatives_)>...>,

--- a/tests/src/testadaptivestepsizing.cpp
+++ b/tests/src/testadaptivestepsizing.cpp
@@ -143,7 +143,9 @@ auto KLShellAndAdaptiveStepSizing(const PathFollowingType& pft, const std::vecto
 
   int loadSteps = 6;
 
-  auto nrConfig = NewtonRaphsonWithSubsidiaryFunctionConfig<decltype(linSolver)>{.linearSolver = linSolver};
+  auto nrConfig =
+      NewtonRaphsonWithSubsidiaryFunctionConfig<Ikarus::ConvergenceCriterion::ResiduumNorm, decltype(linSolver)>{
+          .linearSolver = linSolver};
 
   NonlinearSolverFactory nrFactory(nrConfig);
   auto nr  = nrFactory.create(sparseAssembler);

--- a/tests/src/testpathfollowing.cpp
+++ b/tests/src/testpathfollowing.cpp
@@ -42,7 +42,8 @@ static auto simple2DOperatorArcLengthTest(NonLinearOperator& nonLinOp, double st
   auto linSolver = Ikarus::LinearSolver(Ikarus::SolverTypeTag::d_LDLT);
   auto pft       = Ikarus::ArcLength{}; // Type of path following technique
 
-  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<decltype(linSolver)>{.linearSolver = linSolver};
+  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<Ikarus::ConvergenceCriterion::ResiduumNorm,
+                                                                      decltype(linSolver)>{.linearSolver = linSolver};
   auto nr         = Ikarus::createNonlinearSolver(nrSettings, nonLinOp);
 
   auto alc = Ikarus::PathFollowing(nr, loadSteps, stepSize, pft);
@@ -70,7 +71,8 @@ template <typename NonLinearOperator>
 static auto simple2DOperatorArcLengthTestAsDefault(NonLinearOperator& nonLinOp, double stepSize, int loadSteps) {
   resetNonLinearOperatorParametersToZero(nonLinOp);
   auto linSolver  = Ikarus::LinearSolver(Ikarus::SolverTypeTag::d_LDLT);
-  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<decltype(linSolver)>{.linearSolver = linSolver};
+  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<Ikarus::ConvergenceCriterion::ResiduumNorm,
+                                                                      decltype(linSolver)>{.linearSolver = linSolver};
   auto nr         = Ikarus::createNonlinearSolver(nrSettings, nonLinOp);
   auto alc        = Ikarus::PathFollowing(nr, loadSteps, stepSize);
   auto nonLinearSolverObserver = std::make_shared<Ikarus::NonLinearSolverLogger>();
@@ -98,7 +100,8 @@ static auto simple2DOperatorLoadControlTest(NonLinearOperator& nonLinOp, double 
   auto linSolver = Ikarus::LinearSolver(Ikarus::SolverTypeTag::d_LDLT);
   auto pft       = Ikarus::LoadControlSubsidiaryFunction{}; // Type of path following technique
 
-  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<decltype(linSolver)>{.linearSolver = linSolver};
+  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<Ikarus::ConvergenceCriterion::ResiduumNorm,
+                                                                      decltype(linSolver)>{.linearSolver = linSolver};
   auto nr         = Ikarus::createNonlinearSolver(nrSettings, nonLinOp);
   auto lc         = Ikarus::PathFollowing(nr, loadSteps, stepSize, pft);
   auto nonLinearSolverObserver = std::make_shared<Ikarus::NonLinearSolverLogger>();
@@ -128,7 +131,8 @@ static auto simple2DOperatorDisplacementControlTest(NonLinearOperator& nonLinOp,
 
   auto pft = Ikarus::DisplacementControl{controlledIndices}; // Type of path following technique
 
-  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<decltype(linSolver)>{.linearSolver = linSolver};
+  auto nrSettings = Ikarus::NewtonRaphsonWithSubsidiaryFunctionConfig<Ikarus::ConvergenceCriterion::ResiduumNorm,
+                                                                      decltype(linSolver)>{.linearSolver = linSolver};
   auto nr         = Ikarus::createNonlinearSolver(nrSettings, nonLinOp);
   auto dc         = Ikarus::PathFollowing(nr, loadSteps, stepSize, pft);
   auto nonLinearSolverObserver = std::make_shared<Ikarus::NonLinearSolverLogger>();

--- a/tests/src/testtruss.cpp
+++ b/tests/src/testtruss.cpp
@@ -114,7 +114,8 @@ static auto vonMisesTrussTest() {
   /// Choose linear solver
   auto linSolver = LinearSolver(SolverTypeTag::d_LDLT);
 
-  NewtonRaphsonConfig<decltype(linSolver)> nrConfig{.linearSolver = linSolver};
+  NewtonRaphsonConfig<Ikarus::ConvergenceCriterion::ResiduumNorm, decltype(linSolver)> nrConfig{.linearSolver =
+                                                                                                    linSolver};
 
   NonlinearSolverFactory nrFactory(nrConfig);
   auto nr = nrFactory.create(denseFlatAssembler);


### PR DESCRIPTION
See #182

## TO-DOs
- [ ] Change the solver-dependent structs, for example, `NRConvergenceCriteria` to criteria-dependent structs. This should then be overloaded with `bool operator()(...){}` for different solvers. Remove the `MAKE_ENUM` and then pass the criteria-dependent structs directly to the nonlinear solvers. This would allow easy extensibility for the users.
- [ ] Fix the bug in Python tests
- [ ] Implement convergence criteria for trust region method
- [ ] Update CHANGELOG
- [ ] Fix in `ikarus-examples`, if needed
- [ ] Use `DUNE::AlwaysFalse` as per the comments (see `convergencecriteria.hh`)

## Decisions to be made
- [ ] May be a `solverState` is needed to have nice constructors. See also #260