### PR TITLE
Synchronize notion of step count between LoadControl and PathFollowing

### DIFF
--- a/ikarus/controlroutines/loadcontrol.hh
+++ b/ikarus/controlroutines/loadcontrol.hh
@@ -74,7 +74,10 @@ public:
         loadSteps_{loadSteps},
         parameterBegin_{tbeginEnd[0]},
         parameterEnd_{tbeginEnd[1]},
-        stepSize_{(parameterEnd_ - parameterBegin_) / loadSteps_} {}
+        stepSize_{(parameterEnd_ - parameterBegin_) / loadSteps_} {
+    if (loadSteps_ <= 0)
+      DUNE_THROW(Dune::InvalidStateException, "Number of load steps should be greater than zero.");
+  }
 
   /**
    * \brief Executes the LoadControl routine.
@@ -92,6 +95,14 @@ private:
   double parameterBegin_;
   double parameterEnd_;
   double stepSize_;
+
+  void updateAndNotifyControlInfo(ControlInformation& info, const NonLinearSolverInformation& solverInfo,
+                                  const typename LoadControl::State& state) {
+    info.solverInfos.push_back(solverInfo);
+    info.totalIterations += solverInfo.iterations;
+    this->notify(ControlMessages::SOLUTION_CHANGED, state);
+    this->notify(ControlMessages::STEP_ENDED, state);
+  }
 };
 
 } // namespace Ikarus

--- a/ikarus/controlroutines/pathfollowing.hh
+++ b/ikarus/controlroutines/pathfollowing.hh
@@ -36,7 +36,7 @@ struct PathFollowingState
   const ControlInformation& information;
   const SubsidiaryArgs& subsidiaryArgs;
 
-  int loadStep{};
+  int loadStep{-1};
   double stepSize{};
 };
 
@@ -189,7 +189,10 @@ public:
         steps_{steps},
         stepSize_{stepSize},
         pathFollowingType_{pathFollowingType},
-        adaptiveStepSizing_{adaptiveStepSizing} {}
+        adaptiveStepSizing_{adaptiveStepSizing} {
+    if (steps_ <= 0)
+      DUNE_THROW(Dune::InvalidStateException, "Number of steps should be greater than zero.");
+  }
 
   /**
    * \brief Executes the PathFollowing routine.
@@ -211,6 +214,14 @@ private:
   PF pathFollowingType_;
   ASS adaptiveStepSizing_;
   SubsidiaryArgs subsidiaryArgs_;
+
+  void updateAndNotifyControlInfo(ControlInformation& info, const NonLinearSolverInformation& solverInfo,
+                                  const typename PathFollowing::State& state) {
+    info.solverInfos.push_back(solverInfo);
+    info.totalIterations += solverInfo.iterations;
+    this->notify(ControlMessages::SOLUTION_CHANGED, state);
+    this->notify(ControlMessages::STEP_ENDED, state);
+  }
 };
 
 } // namespace Ikarus

--- a/ikarus/controlroutines/pathfollowing.inl
+++ b/ikarus/controlroutines/pathfollowing.inl
@@ -46,6 +46,7 @@ PathFollowing<NLS, PF, ASS>::run(typename NLS::Domain& req) {
     return info;
 
   state.loadStep = 0;
+  state.stepSize = stepSize_;
   this->notify(STEP_STARTED, state);
   pathFollowingType_.initialPrediction(req, residual, subsidiaryArgs_);
   solverInfo = nonLinearSolver_->solve(req, pathFollowingType_, subsidiaryArgs_);

--- a/ikarus/controlroutines/pathfollowing.inl
+++ b/ikarus/controlroutines/pathfollowing.inl
@@ -22,7 +22,10 @@ namespace Ikarus {
 
 template <typename NLS, typename PF, typename ASS>
 requires(Impl::checkPathFollowingTemplates<NLS, PF, ASS>())
-ControlInformation PathFollowing<NLS, PF, ASS>::run(typename NLS::Domain& req) {
+[[nodiscard(
+    "The run method returns information of the control routine. You should store this information and check if "
+    "it was successful")]] ControlInformation
+PathFollowing<NLS, PF, ASS>::run(typename NLS::Domain& req) {
   using enum ControlMessages;
   auto& residual = nonLinearSolver_->residual();
 
@@ -32,26 +35,23 @@ ControlInformation PathFollowing<NLS, PF, ASS>::run(typename NLS::Domain& req) {
   auto state = typename PathFollowing::State(req, info, subsidiaryArgs_);
 
   this->notify(CONTROL_STARTED, state);
-
-  // For Clang, loadStep value gets corrupted only after CONTROL_STARTED and hence it is re-written here
-#if defined(__clang__)
-  state.loadStep = 0;
-#endif
-
   subsidiaryArgs_.stepSize = stepSize_;
 
-  /// Initializing solver
+  // Initial step to check if the undeformed (or initial) state is in equilibrium
+  state.loadStep = -1;
   this->notify(STEP_STARTED, state);
-
-  pathFollowingType_.initialPrediction(req, residual, subsidiaryArgs_);
   auto solverInfo = nonLinearSolver_->solve(req, pathFollowingType_, subsidiaryArgs_);
-  info.solverInfos.push_back(solverInfo);
-  info.totalIterations += solverInfo.iterations;
+  updateAndNotifyControlInfo(info, solverInfo, state);
   if (not solverInfo.success)
     return info;
 
-  this->notify(SOLUTION_CHANGED, state);
-  this->notify(STEP_ENDED, state);
+  state.loadStep = 0;
+  this->notify(STEP_STARTED, state);
+  pathFollowingType_.initialPrediction(req, residual, subsidiaryArgs_);
+  solverInfo = nonLinearSolver_->solve(req, pathFollowingType_, subsidiaryArgs_);
+  updateAndNotifyControlInfo(info, solverInfo, state);
+  if (not solverInfo.success)
+    return info;
 
   /// Calculate predictor for a particular step
   for (int ls = 1; ls < steps_; ++ls) {
@@ -65,14 +65,9 @@ ControlInformation PathFollowing<NLS, PF, ASS>::run(typename NLS::Domain& req) {
     this->notify(STEP_STARTED, state);
 
     solverInfo = nonLinearSolver_->solve(req, pathFollowingType_, subsidiaryArgs_);
-
-    info.solverInfos.push_back(solverInfo);
-    info.totalIterations += solverInfo.iterations;
+    updateAndNotifyControlInfo(info, solverInfo, state);
     if (not solverInfo.success)
       return info;
-
-    this->notify(SOLUTION_CHANGED, state);
-    this->notify(STEP_ENDED, state);
   }
 
   this->notify(CONTROL_ENDED, state);

--- a/ikarus/controlroutines/pathfollowingfunctions.hh
+++ b/ikarus/controlroutines/pathfollowingfunctions.hh
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <dune/common/exceptions.hh>
+#include <dune/common/float_cmp.hh>
 
 #include <Eigen/Core>
 
@@ -86,13 +87,15 @@ struct ArcLength
    * \param args The subsidiary function arguments.
    */
   void operator()(SubsidiaryArgs& args) const {
-    if (psi) {
-      const auto root = sqrt(args.DD.squaredNorm() + psi.value() * psi.value() * args.Dlambda * args.Dlambda);
-      args.f          = root - args.stepSize;
-      args.dfdDD      = args.DD / root;
-      args.dfdDlambda = (psi.value() * psi.value() * args.Dlambda) / root;
+    const auto root = sqrt(args.DD.squaredNorm() + psi * psi * args.Dlambda * args.Dlambda);
+    args.f          = root - args.stepSize;
+    if (Dune::FloatCmp::eq(root, 0.0, std::numeric_limits<double>::epsilon())) {
+      args.dfdDD.resizeLike(args.DD);
+      args.dfdDD.setZero();
+      args.dfdDlambda = 0.0;
     } else {
-      DUNE_THROW(Dune::InvalidStateException, "You have to call initialPrediction first. Otherwise psi is not defined");
+      args.dfdDD      = args.DD / root;
+      args.dfdDlambda = (psi * psi * args.Dlambda) / root;
     }
   }
 
@@ -135,13 +138,14 @@ struct ArcLength
     const auto DD2 = args.DD.squaredNorm();
 
     psi    = sqrt(DD2);
-    auto s = sqrt(psi.value() * psi.value() + DD2);
+    auto s = sqrt(psi * psi + DD2);
 
     args.DD      = args.DD * args.stepSize / s;
     args.Dlambda = args.stepSize / s;
 
-    req.globalSolution() = args.DD;
-    req.parameter()      = args.Dlambda;
+    req.globalSolution()     = args.DD;
+    req.parameter()          = args.Dlambda;
+    computedInitialPredictor = true;
   }
 
   /**
@@ -156,6 +160,8 @@ struct ArcLength
    */
   template <typename F>
   void intermediatePrediction(typename F::Domain& req, F& residual, SubsidiaryArgs& args) {
+    if (not computedInitialPredictor)
+      DUNE_THROW(Dune::InvalidStateException, "initialPrediction has to be called before intermediatePrediction.");
     req.globalSolution() += args.DD;
     req.parameter() += args.Dlambda;
   }
@@ -164,7 +170,8 @@ struct ArcLength
   constexpr std::string name() const { return "Arc length"; }
 
 private:
-  std::optional<double> psi;
+  double psi{0.0};
+  bool computedInitialPredictor{false};
 };
 
 /**
@@ -206,8 +213,9 @@ struct LoadControlSubsidiaryFunction
    */
   template <typename F>
   void initialPrediction(typename F::Domain& req, F& residual, SubsidiaryArgs& args) {
-    args.Dlambda    = args.stepSize;
-    req.parameter() = args.Dlambda;
+    args.Dlambda             = args.stepSize;
+    req.parameter()          = args.Dlambda;
+    computedInitialPredictor = true;
   }
 
   /**
@@ -222,11 +230,16 @@ struct LoadControlSubsidiaryFunction
    */
   template <typename F>
   void intermediatePrediction(typename F::Domain& req, F& residual, SubsidiaryArgs& args) {
+    if (not computedInitialPredictor)
+      DUNE_THROW(Dune::InvalidStateException, "initialPrediction has to be called before intermediatePrediction.");
     req.parameter() += args.Dlambda;
   }
 
   /** \brief The name of the PathFollowing method. */
   constexpr std::string name() const { return "Load Control"; }
+
+private:
+  bool computedInitialPredictor{false};
 };
 
 /**
@@ -280,6 +293,7 @@ struct DisplacementControl
   void initialPrediction(typename F::Domain& req, F& residual, SubsidiaryArgs& args) {
     args.DD(controlledIndices).array() = args.stepSize;
     req.globalSolution()               = args.DD;
+    computedInitialPredictor           = true;
   }
 
   /**
@@ -294,6 +308,8 @@ struct DisplacementControl
    */
   template <typename F>
   void intermediatePrediction(typename F::Domain& req, F& residual, SubsidiaryArgs& args) {
+    if (not computedInitialPredictor)
+      DUNE_THROW(Dune::InvalidStateException, "initialPrediction has to be called before intermediatePrediction.");
     req.globalSolution() += args.DD;
   }
 
@@ -302,5 +318,6 @@ struct DisplacementControl
 
 private:
   std::vector<int> controlledIndices; /**< Vector containing the indices of the controlled degrees of freedom. */
+  bool computedInitialPredictor{false};
 };
 } // namespace Ikarus

--- a/ikarus/controlroutines/pathfollowingfunctions.hh
+++ b/ikarus/controlroutines/pathfollowingfunctions.hh
@@ -89,8 +89,7 @@ struct ArcLength
   void operator()(SubsidiaryArgs& args) const {
     const auto root = sqrt(args.DD.squaredNorm() + psi * psi * args.Dlambda * args.Dlambda);
     args.f          = root - args.stepSize;
-    if (Dune::FloatCmp::eq(root, 0.0, std::numeric_limits<double>::epsilon())) {
-      args.dfdDD.resizeLike(args.DD);
+    if (not computedInitialPredictor) {
       args.dfdDD.setZero();
       args.dfdDlambda = 0.0;
     } else {

--- a/tests/src/testadaptivestepsizing.cpp
+++ b/tests/src/testadaptivestepsizing.cpp
@@ -244,12 +244,12 @@ int main(int argc, char** argv) {
 
   /// expected iterations for each step for a path following type with and without step sizing
   const std::vector<std::vector<int>> expectedIterationsALC = {
-      {9, 9, 6, 5, 4, 4},
-      {9, 8, 6, 5, 5, 5}
+      {0, 9, 9, 6, 5, 4, 4},
+      {0, 9, 8, 6, 5, 5, 5}
   };
   const std::vector<std::vector<int>> expectedIterationsLC = {
-      {10, 4, 4, 3, 3, 3},
-      {10, 6, 5, 4, 4, 4}
+      {0, 10, 4, 4, 3, 3, 3},
+      {0, 10, 6, 5, 4, 4, 4}
   };
 
   /// expected results(max(displacement) and lambda) for a path following type with and without step sizing

--- a/tests/src/testpathfollowing.cpp
+++ b/tests/src/testpathfollowing.cpp
@@ -55,7 +55,7 @@ static auto simple2DOperatorArcLengthTest(DifferentiableFunction& f, typename Di
   auto pathFollowingLogger   = Ikarus::ControlLogger().subscribeTo(alc);
 
   const auto controlInfo              = alc.run(req);
-  std::vector<int> expectedIterations = {1, 3, 3, 3, 3};
+  std::vector<int> expectedIterations = {0, 1, 3, 3, 3, 3};
   Eigen::Vector2d expectedDisplacement;
   expectedDisplacement << 0.0883524725970593, 0.3486891582376427;
   double expectedLambda = 0.4877655288280236;
@@ -63,9 +63,9 @@ static auto simple2DOperatorArcLengthTest(DifferentiableFunction& f, typename Di
   TestSuite t("Arc Length with Subsidiary function");
   t.check(controlInfo.success, "No convergence");
   for (auto i = 0; i < 2; ++i)
-    checkScalars(t, req.globalSolution()[i], expectedDisplacement[i], " --> " + pft.name());
-  checkScalars(t, req.parameter(), expectedLambda, " --> " + pft.name());
-  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps);
+    checkScalars(t, req.globalSolution()[i], expectedDisplacement[i], " --> " + alc.name());
+  checkScalars(t, req.parameter(), expectedLambda, " --> " + alc.name());
+  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps + 1);
   return t;
 }
 
@@ -83,7 +83,7 @@ static auto simple2DOperatorArcLengthTestAsDefault(DifferentiableFunction& f,
   auto pathFollowingLogger   = Ikarus::ControlLogger().subscribeTo(alc);
 
   const auto controlInfo              = alc.run(req);
-  std::vector<int> expectedIterations = {1, 3, 3, 3, 3};
+  std::vector<int> expectedIterations = {0, 1, 3, 3, 3, 3};
   Eigen::Vector2d expectedDisplacement;
   expectedDisplacement << 0.0883524725970593, 0.3486891582376427;
   double expectedLambda = 0.4877655288280236;
@@ -93,7 +93,7 @@ static auto simple2DOperatorArcLengthTestAsDefault(DifferentiableFunction& f,
   for (auto i = 0; i < 2; ++i)
     checkScalars(t, req.globalSolution()[i], expectedDisplacement[i]);
   checkScalars(t, req.parameter(), expectedLambda);
-  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps);
+  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps + 1);
   return t;
 }
 
@@ -112,17 +112,35 @@ static auto simple2DOperatorLoadControlTestPF(DifferentiableFunction& f, typenam
   auto pathFollowingLogger   = Ikarus::ControlLogger().subscribeTo(lc);
 
   const auto controlInfo              = lc.run(req);
-  std::vector<int> expectedIterations = {2, 3, 3, 3, 3};
-  Eigen::Vector2d expectedDisplacement;
-  expectedDisplacement << 0.0908533884835060, 0.3581294588381901;
+  std::vector<int> expectedIterations = {0, 2, 3, 3, 3, 3};
+  Eigen::Matrix2Xd expectedDisplacement;
+  expectedDisplacement.setZero(Eigen::NoChange, loadSteps + 1);
+  expectedDisplacement << 0.0, 0.01715872957844366, 0.0345464428730192, 0.0524126112865617, 0.0710534689402604,
+      0.0908533884835060, 0.0, 0.0691806374841585, 0.1389097864303651, 0.2097895325120464, 0.2825443193976919,
+      0.3581294588381901;
   double expectedLambda = 0.5;
+
+  /// Create GenericListener which executes when control routines messages to check displacements at every step
+  Eigen::Matrix2Xd dispMat;
+  dispMat.setZero(Eigen::NoChange, loadSteps + 1);
+
+  auto dispObserver = Ikarus::GenericListener(lc, Ikarus::ControlMessages::SOLUTION_CHANGED, [&](const auto& state) {
+    const auto& d        = state.domain.globalSolution();
+    int step             = state.loadStep;
+    dispMat(0, step + 1) = d[0];
+    dispMat(1, step + 1) = d[1];
+  });
 
   TestSuite t("Load Control with Subsidiary function");
   t.check(controlInfo.success, "No convergence");
   for (auto i = 0; i < 2; ++i)
-    checkScalars(t, req.globalSolution()[i], expectedDisplacement[i], " --> " + pft.name());
-  checkScalars(t, req.parameter(), expectedLambda, " --> " + pft.name());
-  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps);
+    for (auto j = 0; j < loadSteps + 1; ++j)
+      checkScalars(t, dispMat(i, j), expectedDisplacement(i, j), " --> " + lc.name());
+  checkScalars(t, req.parameter(), expectedLambda, " --> " + lc.name());
+  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps + 1);
+  t.checkThrow<Dune::InvalidStateException>(
+      [&]() { auto lc1 = Ikarus::PathFollowing(nr, 0, stepSize, pft); },
+      "An object of PathFollowing should not have been constructed with steps = 0.");
   return t;
 }
 
@@ -166,7 +184,10 @@ static auto simple2DOperatorLoadControlTestLC(DifferentiableFunction& f, typenam
     for (auto j = 0; j < loadSteps; ++j)
       checkScalars(t, dispMat(i, j), expectedDisplacement(i, j), " --> " + lc.name());
   checkScalars(t, req.parameter(), expectedLambda, " --> " + lc.name());
-  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps);
+  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps + 1);
+  t.checkThrow<Dune::InvalidStateException>(
+      [&]() { auto lc1 = Ikarus::LoadControl(nr, 0, {0, 1}); },
+      "An object of LoadControl should not have been constructed with loadSteps = 0.");
   return t;
 }
 
@@ -211,7 +232,7 @@ static auto simple2DOperatorLoadControlTestLCWithDifferentListenerOrder(Differen
     for (auto j = 0; j < loadSteps; ++j)
       checkScalars(t, dispMat(i, j), expectedDisplacement(i, j), " --> " + lc.name());
   checkScalars(t, req.parameter(), expectedLambda, " --> " + lc.name());
-  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps);
+  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps + 1);
   return t;
 }
 
@@ -233,7 +254,7 @@ static auto simple2DOperatorDisplacementControlTest(DifferentiableFunction& f,
   auto pathFollowingLogger   = Ikarus::ControlLogger().subscribeTo(dc);
 
   const auto controlInfo              = dc.run(req);
-  std::vector<int> expectedIterations = {3, 3, 3, 3, 3};
+  std::vector<int> expectedIterations = {0, 3, 3, 3, 3, 3};
   Eigen::Vector2d expectedDisplacement;
   expectedDisplacement << 0.5, 1.4781013410920430;
   double expectedLambda = 0.5045466678049050;
@@ -241,9 +262,9 @@ static auto simple2DOperatorDisplacementControlTest(DifferentiableFunction& f,
   TestSuite t("Displacement Control with Subsidiary function");
   t.check(controlInfo.success, "No convergence");
   for (auto i = 0; i < 2; ++i)
-    checkScalars(t, req.globalSolution()[i], expectedDisplacement[i], " --> " + pft.name());
-  checkScalars(t, req.parameter(), expectedLambda, " --> " + pft.name());
-  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps);
+    checkScalars(t, req.globalSolution()[i], expectedDisplacement[i], " --> " + dc.name());
+  checkScalars(t, req.parameter(), expectedLambda, " --> " + dc.name());
+  checkSolverInfos(t, expectedIterations, controlInfo, loadSteps + 1);
   return t;
 }
 
@@ -263,8 +284,8 @@ int main(int argc, char** argv) {
 
   auto f = Ikarus::makeDifferentiableFunction(Ikarus::functions(fvLambda, dfvLambda), req);
 
-  double stepSize = 0.1;
-  int loadSteps   = 5;
+  constexpr double stepSize = 0.1;
+  constexpr int loadSteps   = 5;
 
   t.subTest(simple2DOperatorArcLengthTest(f, req, stepSize, loadSteps));
   t.subTest(simple2DOperatorArcLengthTestAsDefault(f, req, stepSize, loadSteps));

--- a/tests/src/testpathfollowing.cpp
+++ b/tests/src/testpathfollowing.cpp
@@ -110,7 +110,7 @@ static auto simple2DOperatorLoadControlTestPF(DifferentiableFunction& f, typenam
   auto lc                    = Ikarus::PathFollowing(nr, loadSteps, stepSize, pft);
   auto nonLinearSolverLogger = Ikarus::NonLinearSolverLogger().subscribeTo(*nr);
   auto pathFollowingLogger   = Ikarus::ControlLogger().subscribeTo(lc);
-  
+
   /// Create GenericListener which executes when control routines messages to check displacements at every step
   Eigen::Matrix2Xd dispMat;
   dispMat.setZero(Eigen::NoChange, loadSteps + 1);


### PR DESCRIPTION
At the moment, `LoadControl` has an additional step that checks if the undeformed or the initial state is in equilibrium, while this is missing in `PathFollowing`. Consequently, for example, one cannot visualize the undeformed state in an output .vtk file when using `PathFollowing` but can only do it while using `LoadControl`. This notion is synchronized in this PR.

Consequently, in `ArcLength`, where `psi` is of type `std::optional<double>` designed such that `initialPrediction` is called first, is now only a `double` and a new `bool computedInitialPredictor` checks if `initialPrediction` is called first. This, however, will not have a bigger impact, as the interface is dictated by `PathFollowing::run()` that always calls `initialPrediction` first.