### PR TITLE
Fix globalIndexFromGlobalPosition and forEachLagrangeNodePosition

### DIFF
--- a/ikarus/utils/traversal.hh
+++ b/ikarus/utils/traversal.hh
@@ -54,24 +54,24 @@ void forEachLeafOrPowerLeafNode(T&& tree, TreePath&& treePath, PowerFunc&& power
  * \brief A helper function that helps in traversing over the local coordinates of an element and
  * call a user-desired function
  * \see Dune book page 314 for details
- * \tparam size Size of the global nodal coordinate vector
+ * \tparam myDim Dimension of the geometry
  * \tparam LV Type of the local view
  * \tparam F Type of the functor that traverses over the local coordinate of an element
  * \param localView Local view bounded to an element
  * \param f A function that traverses over the local coordinate of an element
  */
-template <typename LV, typename F, int size = LV::Element::Geometry::coorddimension>
-requires(std::convertible_to<F, std::function<bool(int, Dune::FieldVector<double, size> &&)>>)
+template <typename LV, typename F, int myDim = LV::Element::mydimension>
+requires(std::convertible_to<F, std::function<bool(int, Dune::FieldVector<double, myDim> &&)>>)
 void forEachLagrangeNodePosition(const LV& localView, F&& f) {
   static_assert(Concepts::LagrangeNode<std::remove_cvref_t<decltype(localView.tree().child(0))>>,
                 "forEachLagrangeNodePosition is only supported for Lagrange power basis");
   assert(localView.bound() && "The local view must be bound to an element");
   const auto& localFE = localView.tree().child(0).finiteElement();
-  std::vector<Dune::FieldVector<double, size>> lagrangeNodeCoords;
+  std::vector<Dune::FieldVector<double, myDim>> lagrangeNodeCoords;
   lagrangeNodeCoords.resize(localFE.size());
   std::vector<double> out;
-  for (int i = 0; i < size; i++) {
-    auto ithCoord = [&i](const Dune::FieldVector<double, size>& x) { return x[i]; };
+  for (int i = 0; i < myDim; i++) {
+    auto ithCoord = [&i](const Dune::FieldVector<double, myDim>& x) { return x[i]; };
     localFE.localInterpolation().interpolate(ithCoord, out);
     for (std::size_t j = 0; j < out.size(); j++)
       lagrangeNodeCoords[j][i] = out[j];

--- a/tests/src/testtruss.cpp
+++ b/tests/src/testtruss.cpp
@@ -88,8 +88,10 @@ static auto vonMisesTrussTest() {
   auto req = FEType::Requirement(basis);
   denseFlatAssembler->bind(req, AffordanceCollections::elastoStatics, DBCOption::Full);
 
-  auto pointLoad = [&](const auto&, const auto&, auto, auto, Eigen::VectorXd& vec) -> void {
-    vec[3] -= -req.parameter();
+  Dune::FieldVector<double, 2> pointLoadPos{L, h};
+  const auto globalIndicesAtPointLoadPos = utils::globalIndexFromGlobalPosition(basis.flat(), pointLoadPos);
+  auto pointLoad                         = [&](const auto&, const auto&, auto, auto, Eigen::VectorXd& vec) -> void {
+    vec[globalIndicesAtPointLoadPos[1]] -= -req.parameter();
   };
   denseFlatAssembler->bind(pointLoad);
 


### PR DESCRIPTION
Template parameter `size` was incorrect in `globalIndexFromGlobalPosition` and in `forEachLagrangeNodePosition` and only worked correctly when `worldDim == myDim`. This is now fixed and thereby enabling point load applications also for truss systems